### PR TITLE
Fix #32 &  #30 background the tail command and wait

### DIFF
--- a/src/scripts/start_valheim.sh
+++ b/src/scripts/start_valheim.sh
@@ -64,7 +64,3 @@ Keep an eye out for 'Game server connected' in the log!
 tail -f /home/steam/valheim/output.log &
 export TAIL_PID=$!
 wait $TAIL_PID
-
-while :; do
-  sleep 1s
-done

--- a/src/scripts/start_valheim.sh
+++ b/src/scripts/start_valheim.sh
@@ -58,7 +58,8 @@ Valheim Server Started...
 Keep an eye out for 'Game server connected' in the log!
 (this indicates its online without any errors.)
 " >> /home/steam/valheim/output.log
-tail -f /home/steam/valheim/output.log
+tail -f /home/steam/valheim/output.log &
+wait $!
 
 while :; do
   sleep 1s

--- a/src/scripts/start_valheim.sh
+++ b/src/scripts/start_valheim.sh
@@ -48,6 +48,9 @@ trap 'cleanup' INT TERM EXIT
 
 cleanup() {
     log "Halting server! Received interrupt!"
+    if [[ -n $TAIL_PID ]];then
+      kill $TAIL_PID
+    fi
     odin stop
     exit
 }
@@ -59,7 +62,8 @@ Keep an eye out for 'Game server connected' in the log!
 (this indicates its online without any errors.)
 " >> /home/steam/valheim/output.log
 tail -f /home/steam/valheim/output.log &
-wait $!
+export TAIL_PID=$!
+wait $TAIL_PID
 
 while :; do
   sleep 1s


### PR DESCRIPTION


# Description

resolves issues with shutdown in docker/kube due to SIGTERM being swallowed by bash due to it waiting for a process to complete. https://ss64.com/bash/trap.html gives the clearest explanation of this

> When Bash receives a signal for which a trap has been set while waiting for a command to complete, the trap will not be executed until the command completes. When Bash is waiting for an asynchronous command via the wait built-in, the reception of a signal for which a trap has been set will cause the wait built-in to return immediately with an exit status greater than 128, immediately after which the trap is executed.




## Contributions
- #32 & #30 backgrounded tail to avoid bash from blocking trap execution until it completes (tail will never complete)
- put function before trap definition to avoid any issues/race conditions with the function not being defined when the trap is made

## Checklist

- [x] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [x] This PR has a reviewer on it. 
- [x] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
