### PR TITLE
Avoid compiling odin twice in dockerfile

### DIFF
--- a/Dockerfile.odin
+++ b/Dockerfile.odin
@@ -6,8 +6,7 @@ FROM rust:latest as RustBuilder
 WORKDIR /data/odin
 COPY . .
 
-RUN cargo install --path . \
-    && cargo build --release
+RUN cargo build --release
 
 ENTRYPOINT ["/data/odin/target/release/odin"]
 CMD ["--version"]


### PR DESCRIPTION
# Description

## Contributions

Unless I'm missing something there is no need to do `cargo install` and `cargo build --release` in `Dockerfile.odin`. `cargo install` will build the executable in a temporary directory and install it into `$HOME/.cargo/bin` while `cargo build --release` will compile the executable in `{PROJECT_DIR/target/release` which I believe is the only one needed in this case.

It's possible that `mbround18/valheim-odin` has some other usage that I'm missing since I'm not super familiar with `docker`, but if not then this should also cut down on image build times. Even if the executable is needed in both places then you could simply use `cargo install` and then copy the executable to `/data/odin/target/release/odin` instead of building it twice.

I finally got everything setup where I can easily test local builds of both images correctly, so I was able to test this one locally and noticed no odd behavior from running the `valheim` container.

## Checklist

- [ ] I added one or multiple labels which best describes this PR.
- [ ] I have tested the changes locally.
- [ ] This PR has a reviewer on it. 
- [ ] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
