### PR TITLE
Shell escape startup script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,12 +115,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,9 +156,7 @@ version = "1.1.0"
 dependencies = [
  "clap",
  "log",
- "serde",
  "sysinfo",
- "tinytemplate",
  "which",
 ]
 
@@ -220,43 +212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "ryu"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
-name = "serde"
-version = "1.0.123"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.123"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -328,16 +283,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tinytemplate"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ada8616fad06a2d0c455adc530de4ef57605a8120cc65da9653e0e9623ca74"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,6 @@ edition = "2018"
 log = "0.4.14"
 clap = { version = "3.0.0-beta.2", features = ["yaml"] }
 which = "4.0.2"
-tinytemplate = "1.1"
-serde = { version = "1.0", features = ["derive"] }
 sysinfo = { version = "0.16.1", default_features = false }
 
 

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -1,6 +1,6 @@
 use crate::executable::create_execution;
 use crate::files::start_server_rusty::{write_rusty_start_script, ValheimArguments};
-use crate::utils::{get_variable, get_working_dir, server_installed};
+use crate::utils::{get_variable, get_working_dir, server_installed, shell_escape};
 use clap::ArgMatches;
 use log::{error, info};
 use std::process::{exit, Stdio};
@@ -11,11 +11,11 @@ pub fn invoke(args: &ArgMatches) {
     let mut command = create_execution("bash");
     let server_executable = &[get_working_dir(), "valheim_server.x86_64".to_string()].join("/");
     let script_args = &ValheimArguments {
-        port: get_variable(args, "port", "2456".to_string()),
-        name: get_variable(args, "name", "Valheim powered by Odin".to_string()),
-        world: get_variable(args, "world", "Dedicated".to_string()),
-        public: get_variable(args, "public", "1".to_string()),
-        password: get_variable(args, "password", "12345".to_string()),
+        port: get_variable(args, "port", "2456"),
+        name: shell_escape(get_variable(args, "name", "Odin \\o/")),
+        world: shell_escape(get_variable(args, "world", "Dedicated")),
+        public: get_variable(args, "public", "1"),
+        password: shell_escape(get_variable(args, "password", "!@#$%^&*()")),
         command: server_executable.to_string(),
     };
     if script_args.password.len() < 5 {

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -12,10 +12,10 @@ pub fn invoke(args: &ArgMatches) {
     let server_executable = &[get_working_dir(), "valheim_server.x86_64".to_string()].join("/");
     let script_args = &ValheimArguments {
         port: get_variable(args, "port", "2456"),
-        name: shell_escape(get_variable(args, "name", "Odin \\o/")),
+        name: shell_escape(get_variable(args, "name", "Valheim powered by Odin")),
         world: shell_escape(get_variable(args, "world", "Dedicated")),
         public: get_variable(args, "public", "1"),
-        password: shell_escape(get_variable(args, "password", "!@#$%^&*()")),
+        password: shell_escape(get_variable(args, "password", "12345")),
         command: server_executable.to_string(),
     };
     if script_args.password.len() < 5 {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -15,26 +15,21 @@ pub fn get_working_dir() -> String {
     }
 }
 
-fn parse_variable(value: String) -> String {
-    return value
-        .trim_start_matches('"')
-        .trim_end_matches('"')
-        .to_string();
-}
-
 pub fn get_variable(args: &ArgMatches, name: &str, default: &str) -> String {
     debug!("Checking env for {}", name);
     if let Ok(env_val) = env::var(name.to_uppercase()) {
         if !env_val.is_empty() {
             debug!("Env variable found {}={}", name, env_val);
-            return parse_variable(env_val);
+            return env_val;
         }
     }
+
     if let Ok(env_val) = env::var(format!("SERVER_{}", name).to_uppercase()) {
         debug!("Env variable found {}={}", name, env_val);
-        return parse_variable(env_val);
+        return env_val;
     }
-    parse_variable(args.value_of(name).unwrap_or(default).to_string())
+
+    args.value_of(name).unwrap_or(default).to_string()
 }
 
 pub fn shell_escape(s: String) -> String {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -22,7 +22,7 @@ fn parse_variable(value: String) -> String {
         .to_string();
 }
 
-pub fn get_variable(args: &ArgMatches, name: &str, default: String) -> String {
+pub fn get_variable(args: &ArgMatches, name: &str, default: &str) -> String {
     debug!("Checking env for {}", name);
     if let Ok(env_val) = env::var(name.to_uppercase()) {
         if !env_val.is_empty() {
@@ -34,11 +34,13 @@ pub fn get_variable(args: &ArgMatches, name: &str, default: String) -> String {
         debug!("Env variable found {}={}", name, env_val);
         return parse_variable(env_val);
     }
-    parse_variable(
-        args.value_of(name)
-            .unwrap_or_else(|| default.as_str())
-            .to_string(),
-    )
+    parse_variable(args.value_of(name).unwrap_or(default).to_string())
+}
+
+pub fn shell_escape(s: String) -> String {
+    // Surround `s` with ' and replace any inner ' with '"'"' will effectively shell escape strings
+    // in bash
+    format!("'{}'", s.replace("'", r#"'"'"'"#))
 }
 
 pub fn server_installed() -> bool {


### PR DESCRIPTION
# Description

## Contributions
- I shell escaped certain values getting placed in `rusty_startup_script.sh`

Note: I tested these changes locally with a server named `Odin \o/` and password of `!@#$%^&*()'` and everything worked as intended.

This is done to address the root cause #73 where values in `rusty_startup_script.sh` were not properly being escaped for bash causing unexpected behavior when dealing with ` `, `$`, `\`, etc.

These changes shell escape the name, world, and password which are all the values that you could _expect_ to see containing these special characters. A nice side effect of this change is that it removes the dependency on `tinytemplate` and `serde` since `tinytemplate` was being an absolute pain when it came to certain special characters and was easily replaced with a simple `format!`. This reduced the number of crates compiled even further down to 54 :tada:

Another side note, there is still unexpected behavior when the name, world, or password starts or ends with any amount of `"` due to trimming them with `parse_variable`. I honestly don't know why this is done to begin with, but this will cause a password like `"don't quote me" -me` to become `don't quote me" -me` (note the missing starting `"`) and will likely be a great source of confusion for anyone who encounters it. Is there a reason for doing this? I feel like a user passing in something with a residual starting or ending `"` would be user error and should not be modified. If trimming double-quotes can be removed then I can make that change in this PR too (or feel free to make the change yourself, I'm calling it for the night after submitting this).

## Checklist

- [x] I added one or multiple labels which best describes this PR.
- [ ] I have tested the changes locally.
- [ ] This PR has a reviewer on it. 
- [ ] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
