### PR TITLE
Delay in busy wait to lower CPU usage during shutdown

### DIFF
--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -1,7 +1,10 @@
 use crate::utils::{get_working_dir, server_installed, VALHEIM_EXECUTABLE_NAME};
+
 use clap::ArgMatches;
 use log::{error, info};
 use sysinfo::{ProcessExt, Signal, System, SystemExt};
+
+use std::{thread, time::Duration};
 
 fn send_shutdown() {
     info!("Scanning for Valheim process");
@@ -33,6 +36,8 @@ fn wait_for_server_exit() {
         let processes = system.get_process_by_name(VALHEIM_EXECUTABLE_NAME);
         if processes.is_empty() {
             break;
+        } else {
+            thread::sleep(Duration::from_millis(100));
         }
     }
     info!("Server has been shutdown successfully!")

--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -37,7 +37,8 @@ fn wait_for_server_exit() {
         if processes.is_empty() {
             break;
         } else {
-            thread::sleep(Duration::from_millis(100));
+            // Delay to keep down CPU usage
+            thread::sleep(Duration::from_secs(1));
         }
     }
     info!("Server has been shutdown successfully!")


### PR DESCRIPTION
# Description

## Contributions
- I added a slight delay when waiting for the server to shutdown to lower CPU usage a bit. It's a bit specific, but I notice that my CPU usage would go up a decent bit when waiting for the server to shutdown.

## Checklist

- [x] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [x] This PR has a reviewer on it. 
- [x] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
