### PR TITLE
Don't copy over all build artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ENV AUTO_BACKUP_ON_SHUTDOWN "0"
 
 COPY --chmod=755 ./src/scripts/*.sh /home/steam/scripts/
 COPY --chmod=755  ./src/scripts/entrypoint.sh /entrypoint.sh
-COPY --from=RustBuilder  --chmod=755 /data/odin/target/release /usr/local/odin
+COPY --from=RustBuilder  --chmod=755 /data/odin/target/release/odin /usr/local/odin/odin
 COPY --chown=steam:steam ./src/scripts/steam_bashrc.sh /home/steam/.bashrc
 
 RUN usermod -u ${PUID} steam                            \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ENV AUTO_BACKUP_ON_SHUTDOWN "0"
 
 COPY --chmod=755 ./src/scripts/*.sh /home/steam/scripts/
 COPY --chmod=755  ./src/scripts/entrypoint.sh /entrypoint.sh
-COPY --from=RustBuilder  --chmod=755 /data/odin/target/release/odin /usr/local/odin
+COPY --from=RustBuilder  --chmod=755 /data/odin/target/release/odin /usr/local/bin/odin
 COPY --chown=steam:steam ./src/scripts/steam_bashrc.sh /home/steam/.bashrc
 
 RUN usermod -u ${PUID} steam                            \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,13 +51,12 @@ ENV AUTO_BACKUP_ON_SHUTDOWN "0"
 
 COPY --chmod=755 ./src/scripts/*.sh /home/steam/scripts/
 COPY --chmod=755  ./src/scripts/entrypoint.sh /entrypoint.sh
-COPY --from=RustBuilder  --chmod=755 /data/odin/target/release/odin /usr/local/odin/odin
+COPY --from=RustBuilder  --chmod=755 /data/odin/target/release/odin /usr/local/odin
 COPY --chown=steam:steam ./src/scripts/steam_bashrc.sh /home/steam/.bashrc
 
 RUN usermod -u ${PUID} steam                            \
     && groupmod -g ${PGID} steam                        \
     && chsh -s /bin/bash steam                          \
-    && ln -s /usr/local/odin/odin /usr/local/bin/odin   \
     && printf "${GITHUB_SHA}\n${GITHUB_REF}\n${GITHUB_REPOSITORY}\n" >/home/steam/.version
 
 


### PR DESCRIPTION
# Description

## Contributions

Nothing too exciting here. Just changing to copy over just the `odin` binary instead of the whole build folder. This should slim down the image by ~200MB. I'm assuming that the binary is copied over then symlinked later because of backwards compatibility reasons?

Also side note, but congratz on the soon to be 200 stars!

## Checklist

- [x] I added one or multiple labels which best describes this PR.
- [ ] I have tested the changes locally.
- [ ] This PR has a reviewer on it. 
- [ ] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
