### PR TITLE
feat: add gdb for improved c# traces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM cm2network/steamcmd:root
 
 RUN apt-get update                     \
     && apt-get install -y              \
-    htop net-tools nano gcc g++        \
+    htop net-tools nano gcc g++ gdb    \
     netcat curl wget zip unzip         \
     cron sudo gosu dos2unix            \
     libsdl2-2.0-0  jq   libc6-dev      \


### PR DESCRIPTION
# Description

Mono emits only native traces, and doesn't yield super interesting stacks on crash

## Contributions

- I changed `Dockerfile` because "adding gdb allots for mono to enhance per thread stacktraces". See [output emitted here for demonstration of the effect](https://github.com/mbround18/valheim-docker/discussions/162#discussioncomment-396292)

## Checklist

- [ ] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [ ] This PR has a reviewer on it. 
- [x] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
