### PR TITLE
Add in flag for updating on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ ENV PUID=1000                           \
     AUTO_BACKUP_REMOVE_OLD="1"          \
     AUTO_BACKUP_DAYS_TO_LIVE="3"        \
     AUTO_BACKUP_ON_UPDATE="0"           \
-    AUTO_BACKUP_ON_SHUTDOWN="0"
+    AUTO_BACKUP_ON_SHUTDOWN="0"         \
+    UPDATE_ON_STARTUP="1"
 
 COPY ./src/scripts/*.sh /home/steam/scripts/
 COPY ./src/scripts/entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 | AUTO_BACKUP_ON_UPDATE    | `0`                    | FALSE    | Create a backup on right before updating and starting your server. |
 | AUTO_BACKUP_ON_SHUTDOWN  | `0`                    | FALSE    | Create a backup on shutdown. |
 | WEBHOOK_URL              | ``                     | FALSE    | Supply this to get information regarding your server's status in a webhook or Discord notification! [Click here to learn how to get a webhook url for Discord](https://help.dashe.io/en/articles/2521940-how-to-create-a-discord-webhook-url) | 
+| UPDATE_ON_STARTUP        | `1`                    | FALSE    | Tries to update the server the container is started. |
 
 ### Docker Compose
 
@@ -99,6 +100,7 @@ services:
       - AUTO_BACKUP_ON_UPDATE=1
       - AUTO_BACKUP_ON_SHUTDOWN=1
       - WEBHOOK_URL="https://discord.com/api/webhooks/IM_A_SNOWFLAKE/AND_I_AM_A_SECRET"
+      - UPDATE_ON_STARTUP=0
     volumes:
       - ./valheim/saves:/home/steam/.config/unity3d/IronGate/Valheim
       - ./valheim/server:/home/steam/valheim

--- a/src/scripts/start_valheim.sh
+++ b/src/scripts/start_valheim.sh
@@ -42,8 +42,12 @@ export SteamAppId=${APPID:-892970}
 
 # Setting up server
 log "Running Install..."
-if [ ! -f "./valheim_server.x86_64" ] || [ "${FORCE_INSTALL:-0}" -eq 1 ]; then
+if [ ! -f "./valheim_server.x86_64" ] || \
+    [ "${FORCE_INSTALL:-0}" -eq 1 ]; then
     odin install || exit 1
+elif [ "${UPDATE_ON_STARTUP:-1}" -eq 1]; then
+    log "Attempting to update before launching the server!"
+    /bin/bash /home/steam/scripts/auto_update.sh
 else
     log "Skipping install process, looks like valheim_server is already installed :)"
 fi


### PR DESCRIPTION
# Description

## Contributions

Just opening this as a possibility. A lot of people seem to expect / want the container to check for updates on startup. Beyond that there seems to be confusion regarding the manual update process.

To remedy this situation this PR adds a flag for checking for updates on startup. I set it as on by default since it seems like a lot of people expect that behavior naturally. This was going to be added with #177, but I don't see any reason why this can't be done separately. I know there was talk about update on shutdown before, but I think update on startup covers this situation better for most people.

## Checklist

- [ ] I added one or multiple labels which best describes this PR.
- [ ] I have tested the changes locally.
- [ ] This PR has a reviewer on it. 
- [ ] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
