### PR TITLE
Update start_valheim.sh

### DIFF
--- a/src/scripts/start_valheim.sh
+++ b/src/scripts/start_valheim.sh
@@ -45,7 +45,7 @@ log "Running Install..."
 if [ ! -f "./valheim_server.x86_64" ] || \
     [ "${FORCE_INSTALL:-0}" -eq 1 ]; then
     odin install || exit 1
-elif [ "${UPDATE_ON_STARTUP:-1}" -eq 1]; then
+elif [ "${UPDATE_ON_STARTUP:-1}" -eq 1 ]; then
     log "Attempting to update before launching the server!"
     /bin/bash /home/steam/scripts/auto_update.sh
 else


### PR DESCRIPTION
# Description
Fix missing trailing whitespace on UPDATE_ON_STARTUP #202 changes.

## Contributions
- Resolves error ```/home/steam/scripts/start_valheim.sh: line 48: [: missing `]'``` logged on container startup and makes UPDATE_ON_STARTUP run as intended.

## Checklist

- [x] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [ ] This PR has a reviewer on it. 
- [x] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
