### PR TITLE
Fix starting up without config

### DIFF
--- a/src/scripts/start_valheim.sh
+++ b/src/scripts/start_valheim.sh
@@ -47,7 +47,12 @@ if [ ! -f "./valheim_server.x86_64" ] || \
     odin install || exit 1
 elif [ "${UPDATE_ON_STARTUP:-1}" -eq 1 ]; then
     log "Attempting to update before launching the server!"
-    /bin/bash /home/steam/scripts/auto_update.sh
+    if [ "${AUTO_BACKUP_ON_UPDATE:=0}" -eq 1 ]; then
+        /bin/bash /home/steam/scripts/auto_backup.sh "pre-update-backup"
+    fi
+
+    log "Installing Updates..."
+    odin install || exit 1
 else
     log "Skipping install process, looks like valheim_server is already installed :)"
 fi


### PR DESCRIPTION
# Description

## Contributions

So apparently I should avoid messing with the shell scripts :sweat_smile:

#202 accidentally allowed for running `odin start` before `odin configure` which means that a fully fresh server install or updating from a pre-config.json era would result in a panic from missing `config.json` (I honestly forgot `odin configure` was a thing). This change just extracts out the only bit of `auto_update.sh` that I really cared about and uses that within the startup script instead of calling the whole startup script.

Would it be possible to avoid `odin configure` entirely? From what I can tell `config.json` is only used within `odin` for `start`, so can we just read the env vars within start instead?

## Checklist

- [x] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [ ] This PR has a reviewer on it. 
- [x] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
