### PR TITLE
Subtract 1 from AUTO_BACKUP_DAYS_TO_LIVE and prune before creating backup

### DIFF
--- a/src/scripts/auto_backup.sh
+++ b/src/scripts/auto_backup.sh
@@ -8,14 +8,16 @@ log() {
   printf "%-16s: %s\n" "${PREFIX}" "$1"
 }
 
-file_name="$(date +"%Y%m%d-%H%M%S")-${1:-"backup"}.tar.gz"
-
 log "Starting auto backup process..."
-odin backup /home/steam/.config/unity3d/IronGate/Valheim "/home/steam/backups/${file_name}" || exit 1
 
 if [ "${AUTO_BACKUP_REMOVE_OLD:=0}" -eq 1 ]; then
     log "Removing old backups..."
     find /home/steam/backups -mtime +$((${AUTO_BACKUP_DAYS_TO_LIVE:-5} - 1)) -exec echo {} \;
 fi
+
+file_name="$(date +"%Y%m%d-%H%M%S")-${1:-"backup"}.tar.gz"
+
+log "Starting auto backup process..."
+odin backup /home/steam/.config/unity3d/IronGate/Valheim "/home/steam/backups/${file_name}" || exit 1
 
 log "Backup process complete! Created ${file_name}"

--- a/src/scripts/auto_backup.sh
+++ b/src/scripts/auto_backup.sh
@@ -14,7 +14,7 @@ log "Starting auto backup process..."
 odin backup /home/steam/.config/unity3d/IronGate/Valheim "/home/steam/backups/${file_name}" || exit 1
 
 if [ "${AUTO_BACKUP_REMOVE_OLD:=0}" -eq 1 ]; then
-    find /home/steam/backups -mtime ${AUTO_BACKUP_DAYS_TO_LIVE:-5} -exec rm {} \;
+    find /home/steam/backups -mtime +${AUTO_BACKUP_DAYS_TO_LIVE:-5} -exec rm {} \;
 fi
 
 log "Backup process complete! Created ${file_name}"

--- a/src/scripts/auto_backup.sh
+++ b/src/scripts/auto_backup.sh
@@ -14,7 +14,7 @@ log "Starting auto backup process..."
 odin backup /home/steam/.config/unity3d/IronGate/Valheim "/home/steam/backups/${file_name}" || exit 1
 
 if [ "${AUTO_BACKUP_REMOVE_OLD:=0}" -eq 1 ]; then
-    find /home/steam/backups -mtime +${AUTO_BACKUP_DAYS_TO_LIVE:-5} -exec rm {} \;
+    find /home/steam/backups -mtime ${AUTO_BACKUP_DAYS_TO_LIVE:-5} -exec rm {} \;
 fi
 
 log "Backup process complete! Created ${file_name}"

--- a/src/scripts/auto_backup.sh
+++ b/src/scripts/auto_backup.sh
@@ -12,12 +12,12 @@ log "Starting auto backup process..."
 
 if [ "${AUTO_BACKUP_REMOVE_OLD:=0}" -eq 1 ]; then
     log "Removing old backups..."
-    find /home/steam/backups -mtime +$((${AUTO_BACKUP_DAYS_TO_LIVE:-5} - 1)) -exec echo {} \;
+    find /home/steam/backups -mtime +$((${AUTO_BACKUP_DAYS_TO_LIVE:-5} - 1)) -exec rm {} \;
 fi
 
+log "Creating backup..."
 file_name="$(date +"%Y%m%d-%H%M%S")-${1:-"backup"}.tar.gz"
 
-log "Starting auto backup process..."
 odin backup /home/steam/.config/unity3d/IronGate/Valheim "/home/steam/backups/${file_name}" || exit 1
 
 log "Backup process complete! Created ${file_name}"

--- a/src/scripts/auto_backup.sh
+++ b/src/scripts/auto_backup.sh
@@ -14,7 +14,8 @@ log "Starting auto backup process..."
 odin backup /home/steam/.config/unity3d/IronGate/Valheim "/home/steam/backups/${file_name}" || exit 1
 
 if [ "${AUTO_BACKUP_REMOVE_OLD:=0}" -eq 1 ]; then
-    find /home/steam/backups -mtime +${AUTO_BACKUP_DAYS_TO_LIVE:-5} -exec rm {} \;
+    log "Removing old backups..."
+    find /home/steam/backups -mtime +$((${AUTO_BACKUP_DAYS_TO_LIVE:-5} - 1)) -exec echo {} \;
 fi
 
 log "Backup process complete! Created ${file_name}"


### PR DESCRIPTION
Fixes #289

# Description

## Contributions
- I removed + on auto-backup script -mtime parameter as it should be interpreted as an exact match between AUTO_BACKUP_DAYS_TO_LIVE and the calculated integer-truncated value.

## Checklist

- [x] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [ ] This PR has a reviewer on it. 
- [x] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
