### PR TITLE
Don't overwrite existing config files

### DIFF
--- a/src/odin/commands/install_mod.rs
+++ b/src/odin/commands/install_mod.rs
@@ -7,7 +7,7 @@ pub fn invoke(args: &ArgMatches) {
   let mut valheim_mod = ValheimMod::new(args.value_of("URL").unwrap());
   info!("Installing {}", valheim_mod.url);
   debug!("Mod URL: {}", valheim_mod.url);
-  debug!("Mod staging location: {}", valheim_mod.staging_location);
+  debug!("Mod staging location: {:?}", valheim_mod.staging_location);
   match valheim_mod.download() {
     Ok(_) => valheim_mod.install(),
     Err(message) => {

--- a/src/odin/mods/mod.rs
+++ b/src/odin/mods/mod.rs
@@ -4,14 +4,15 @@ use crate::constants::SUPPORTED_FILE_TYPES;
 use crate::utils::common_paths::{
   bepinex_config_directory, bepinex_plugin_directory, game_directory,
 };
-use crate::utils::{common_paths, get_md5_hash, parse_file_name, path_exists, url_parse_file_type};
+use crate::utils::{common_paths, get_md5_hash, parse_file_name, url_parse_file_type};
 use fs_extra::dir;
 use fs_extra::dir::CopyOptions;
 use log::{debug, error, info};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
-use std::fs::{create_dir_all, File};
-use std::path::Path;
+use std::fs::{self, create_dir_all, File};
+use std::io;
+use std::path::{Path, PathBuf};
 use std::process::exit;
 use zip::result::ZipError;
 use zip::ZipArchive;
@@ -19,7 +20,7 @@ use zip::ZipArchive;
 pub struct ValheimMod {
   pub(crate) url: String,
   pub(crate) file_type: String,
-  pub(crate) staging_location: String,
+  pub(crate) staging_location: PathBuf,
   pub(crate) installed: bool,
   pub(crate) downloaded: bool,
   pub(crate) staged: bool,
@@ -36,7 +37,7 @@ impl ValheimMod {
     ValheimMod {
       url: String::from(url),
       file_type,
-      staging_location: common_paths::mods_directory(),
+      staging_location: common_paths::mods_directory().into(),
       installed: false,
       downloaded: false,
       staged: false,
@@ -55,17 +56,18 @@ impl ValheimMod {
       // TODO: Remove Exit Code and provide an Ok or Err.
       exit(1);
     }
+
     let working_directory = game_directory();
-    let mut staging_output = String::from(&self.staging_location);
-    let sub_dir = format!("{}/{}", &staging_output, &manifest.name);
-    debug!("Manifest suggests sub directory: {}", sub_dir);
+    let mut staging_output = self.staging_location.clone();
+    let sub_dir = &staging_output.join(&manifest.name);
+    debug!("Manifest suggests sub directory: {}", sub_dir.display());
     let mut dir_copy_options = dir::CopyOptions::new();
     dir_copy_options.overwrite = true;
     let mut copy_destination = bepinex_plugin_directory();
-    if path_exists(&sub_dir)
+    if sub_dir.exists()
       && (manifest.name.eq("BepInExPack_Valheim") || manifest.name.eq("BepInEx_Valheim_Full"))
     {
-      staging_output = format!("{}/{}", &staging_output, &manifest.name);
+      staging_output = staging_output.join(&manifest.name);
       copy_destination = String::from(&working_directory);
     } else {
       copy_destination = format!("{}/{}", &copy_destination, &manifest.name);
@@ -81,7 +83,8 @@ impl ValheimMod {
     }
     debug!(
       "Copying contents from: \n{}\nInto Directory:\n{}",
-      &staging_output, &working_directory
+      &staging_output.display(),
+      &working_directory
     );
     let source_contents: Vec<_> = std::fs::read_dir(&staging_output)
       .unwrap()
@@ -96,15 +99,23 @@ impl ValheimMod {
       }
     }
   }
-  fn copy_single_file(&self, from: &str, to: String) {
+
+  fn copy_single_file<P1, P2>(&self, from: P1, to: P2)
+  where
+    P1: AsRef<Path>,
+    P2: AsRef<Path>,
+  {
+    let to = to.as_ref();
+    let from = from.as_ref();
+
     let mut dir_options = CopyOptions::new();
     dir_options.overwrite = true;
     match fs_extra::copy_items(&[&from], &to, &dir_options) {
-      Ok(_) => debug!("Successfully copied {} to {}", &from, &to),
+      Ok(_) => debug!("Successfully copied {:?} to {:?}", from, to),
       Err(_) => {
         error!("Failed to install {}", self.url);
         error!(
-          "File failed to copy from: \n{}To Destination:{}",
+          "File failed to copy from: \n{:?}To Destination:{:?}",
           &from, &to
         );
         // TODO: Remove Exit Code and provide an Ok or Err.
@@ -112,23 +123,19 @@ impl ValheimMod {
       }
     };
   }
+
   fn stage_plugin(&mut self, archive: &mut ZipArchive<File>) {
-    let mut staging_output = String::from(
-      Path::new(&self.staging_location)
-        .file_stem()
-        .unwrap()
-        .to_str()
-        .unwrap(),
-    );
-    staging_output = format!("{}/{}", common_paths::mods_directory(), &staging_output);
+    let file_stem = Path::new(&self.staging_location).file_stem().unwrap();
+    let staging_output = Path::new(&common_paths::mods_directory()).join(&file_stem);
     debug!(
-      "Extracting contents to staging directory: {}",
+      "Extracting contents to staging directory: {:?}",
       staging_output
     );
     archive.extract(&staging_output).unwrap();
     self.staging_location = staging_output;
     self.staged = true;
   }
+
   fn extract_plugin(&self, archive: &mut ZipArchive<File>) {
     let output_path = if archive
       .file_names()
@@ -144,9 +151,9 @@ impl ValheimMod {
       Ok(_) => info!("Successfully installed {}", &self.url),
       Err(msg) => {
         error!(
-          "Failed to install: {}\nDownloaded Archive: {}\n{}",
-          &self.url,
-          &self.staging_location,
+          "Failed to install: {}\nDownloaded Archive: {:?}\n{}",
+          self.url,
+          self.staging_location,
           msg.to_string()
         );
         // TODO: Remove Exit Code and provide an Ok or Err.
@@ -154,28 +161,64 @@ impl ValheimMod {
       }
     };
   }
+
+  fn _extract_plugin<P: AsRef<Path>>(&self, directory: P, archive: &mut ZipArchive<File>) {
+    for i in 0..archive.len() {
+      let mut file = archive.by_index(i).unwrap();
+      let filepath = file.enclosed_name().unwrap();
+
+      let outpath = directory.as_ref().join(filepath);
+
+      if file.name().ends_with('/') {
+        fs::create_dir_all(&outpath).unwrap();
+      } else {
+        if let Some(p) = outpath.parent() {
+          if !p.exists() {
+            fs::create_dir_all(&p).unwrap();
+          }
+        }
+        // TODO: check in here for existing config file
+        let mut outfile = fs::File::create(&outpath).unwrap();
+        io::copy(&mut file, &mut outfile).unwrap();
+      }
+    }
+  }
+
   pub fn install(&mut self) {
     if Path::new(&self.staging_location).is_dir() {
       error!(
-        "Failed to install mod! Staging location is a directory! {}",
-        &self.staging_location
+        "Failed to install mod! Staging location is a directory! {:?}",
+        self.staging_location
       );
       // TODO: Remove Exit Code and provide an Ok or Err.
       exit(1)
     }
+
     if self.file_type.eq("dll") {
-      self.copy_single_file(&self.staging_location, bepinex_plugin_directory());
+      self.copy_single_file(&self.staging_location, &bepinex_plugin_directory());
     } else if self.file_type.eq("cfg") {
-      self.copy_single_file(&self.staging_location, bepinex_config_directory());
+      // If the config file already exists, move the new one next to it and append .new
+      let filepath = Path::new(&self.staging_location);
+      let filename = filepath.file_name().unwrap();
+      if !Path::new(&bepinex_config_directory())
+        .join(filename)
+        .exists()
+      {
+        self.copy_single_file(&self.staging_location, &bepinex_config_directory());
+      } else {
+        // TODO: change here
+        // let duplicate = format!("{}.new", self.staging_location);
+        self.copy_single_file(&self.staging_location, &bepinex_config_directory());
+      }
     } else {
       let zip_file = std::fs::File::open(&self.staging_location).unwrap();
       let mut archive = match zip::ZipArchive::new(zip_file) {
         Ok(file_archive) => {
-          debug!("Successfully parsed zip file {}", &self.staging_location);
+          debug!("Successfully parsed zip file {:?}", self.staging_location);
           file_archive
         }
         Err(_) => {
-          error!("Failed to parse zip file {}", &self.staging_location);
+          error!("Failed to parse zip file {:?}", self.staging_location);
           // TODO: Remove Exit Code and provide an Ok or Err.
           exit(1);
         }
@@ -200,8 +243,8 @@ impl ValheimMod {
     if !Path::new(&self.staging_location).exists() {
       error!("Failed to download file to staging location!");
       return Err(format!(
-        "Directory does not exist! {}",
-        &self.staging_location
+        "Directory does not exist! {:?}",
+        self.staging_location
       ));
     }
     if let Ok(parsed_url) = Url::parse(&download_url) {
@@ -217,13 +260,13 @@ impl ValheimMod {
             &Url::parse(&self.url).unwrap(),
             format!("{}.{}", get_md5_hash(&download_url), &self.file_type).as_str(),
           );
-          self.staging_location = format!("{}/{}", &self.staging_location, file_name);
-          debug!("Downloading to: {}", &self.staging_location);
+          self.staging_location = self.staging_location.join(file_name);
+          debug!("Downloading to: {:?}", self.staging_location);
           let mut file = File::create(&self.staging_location).unwrap();
           response.copy_to(&mut file).expect("Failed saving mod file");
           self.downloaded = true;
           debug!("Download Complete!: {}", &self.url);
-          debug!("Download Output: {}", &self.staging_location);
+          debug!("Download Output: {:?}", self.staging_location);
           Ok(String::from("Successful"))
         }
         Err(err) => {

--- a/src/odin/mods/mod.rs
+++ b/src/odin/mods/mod.rs
@@ -1,6 +1,9 @@
 pub mod bepinex;
 
-use crate::utils::{common_paths, get_md5_hash, parse_file_name, url_parse_file_type};
+use crate::{
+  constants::SUPPORTED_FILE_TYPES,
+  utils::{common_paths, get_md5_hash, parse_file_name, url_parse_file_type},
+};
 use fs_extra::dir::CopyOptions;
 use log::{debug, error, info};
 use reqwest::Url;
@@ -244,9 +247,11 @@ impl ValheimMod {
     if let Ok(parsed_url) = Url::parse(&download_url) {
       match reqwest::blocking::get(parsed_url) {
         Ok(mut response) => {
-          debug!("Using url (in case of redirect): {}", &self.url);
-          self.url = response.url().to_string();
-          self.file_type = url_parse_file_type(&response.url().to_string());
+          if !SUPPORTED_FILE_TYPES.contains(&self.file_type.as_str()) {
+            debug!("Using url (in case of redirect): {}", &self.url);
+            self.url = response.url().to_string();
+            self.file_type = url_parse_file_type(&response.url().to_string());
+          }
 
           let file_name = parse_file_name(
             &Url::parse(&self.url).unwrap(),


### PR DESCRIPTION
# Description

## Contributions

These changes handle keeping old config files and writing new config files next to them by appending a `.new` suffix (as mentioned in #294).

I unified the extraction logic so that all mods are compressed mods are extracted directly instead of some being copied to a staging location. This involved a custom extraction function since the reasoning for extracting to a staging location then copying seems to be from how both BepInEx and BepInExFull are installed since it only includes a sub-directory within the zip file. The custom extraction function is also currently what handles keeping old config files.

The only other place that needed to be handled specifically was downloading a config file directly, which just checks to see if a config exists with the same name, and appends a `.new` to the new config file if that is the case.

I tested this locally with my (incomplete) test harness and it seemed to work correctly for all the mod frameworks as well as mods from thunderstore and directly including `cfg` files.

I'm leaving #294 open currently since it also mentioned backing up config files which is not done in this PR.

## Checklist

- [ ] I added one or multiple labels which best describes this PR.
- [ ] I have tested the changes locally.
- [ ] This PR has a reviewer on it. 
- [ ] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
