### PR TITLE
Fix crash from `.version` file in BepInEx Full having no extension

### DIFF
--- a/src/odin/mods/mod.rs
+++ b/src/odin/mods/mod.rs
@@ -46,7 +46,7 @@ impl ZipExt for ZipArchive<File> {
         }
 
         // Don't overwrite old cfg files
-        if outpath.extension().unwrap() == "cfg" && outpath.exists() {
+        if outpath.extension().unwrap_or_default() == "cfg" && outpath.exists() {
           outpath = outpath.with_extension("cfg.new");
         }
         let mut outfile = File::create(&outpath)?;


### PR DESCRIPTION
# Description

## Contributions

Thanks for pointing out the issue @ouvoun! This fixes a crash caused by unwrapping the extension on files in a zip which failed on `.version` because it doesn't have an extension.

## Checklist

- [ ] I added one or multiple labels which best describes this PR.
- [ ] I have tested the changes locally.
- [ ] This PR has a reviewer on it. 
- [ ] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
