### PR TITLE
Step 3 downloads outdated "Valheim Plus" mod

### DIFF
--- a/docs/bepinex.md
+++ b/docs/bepinex.md
@@ -21,7 +21,7 @@
 3. Download BepInEx
 
   ```shell
-  wget -O /home/steam/tmp/bepinex.zip https://github.com/valheimPlus/ValheimPlus/releases/download/0.9.4/UnixServer.zip
+  wget -O /home/steam/tmp/bepinex.zip https://github.com/valheimPlus/ValheimPlus/releases/download/0.9.7/UnixServer.zip
   ```
 
 4. Extract the BepInEx zip file


### PR DESCRIPTION
# Description
While following the tutorial *bepinex.md*, step 3 causes a compatibility error if the client has a newer version of **Valheim Plus**. This error is somewhat guaranteed as the stable release is newer than specified in step 3.

## Contributions
- Changed step 3 to reflect up-to-date "Valheim Plus"

## Checklist

- [x] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [ ] This PR has a reviewer on it. 
- [x] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
