### PR TITLE
add support for custom post-install scripts

### DIFF
--- a/src/scripts/start_valheim.sh
+++ b/src/scripts/start_valheim.sh
@@ -122,9 +122,9 @@ if [ ! "${TYPE}" = "vanilla" ]; then
   done
 fi
 
-if [ -d /start-valheim-post-install.d/ ]; then
+if [ -d "/valheim-post-install.d/" ]; then
   log "Executing post-install scripts"
-  find /start-valheim-post-install.d/ -type f -executable -exec {} \;
+  find /valheim-post-install.d/ -type f -executable -exec {} \;
 fi
 
 if [ -n "${HTTP_PORT}" ]; then

--- a/src/scripts/start_valheim.sh
+++ b/src/scripts/start_valheim.sh
@@ -122,6 +122,11 @@ if [ ! "${TYPE}" = "vanilla" ]; then
   done
 fi
 
+if [ -d /start-valheim-post-install.d/ ]; then
+  log "Executing post-install scripts"
+  find /start-valheim-post-install.d/ -type f -executable -exec {} \;
+fi
+
 if [ -n "${HTTP_PORT}" ]; then
   huginn &
   export ODIN_HTTP_SERVER_PID=$!


### PR DESCRIPTION
# Description
Adds a script hook to define custom scripts after the installation completes. This allows me to copy from a ConfigMap in kubernetes the configuration files for valheim plus et al. Example post-install script:

```
#!/usr/bin/env bash
set -ex

rm -rf /home/steam/valheim/BepInEx/config
cp -r /home/steam/bep-config /home/steam/valheim/BepInEx/config
chown -R 1000:1000 /home/steam/valheim/BepInEx/config
```

Where `/home/steam/bep-config` is a volume in kubernetes pointing to a ConfigMap.

## Contributions

- I changed the startup script because I couldn't attach extra logic between the mod installation and server startup.
- Added logic executing all scripts under `/valheim-post-install.d/` before the valheim server starts.

## Checklist

- [ ] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [ ] This PR has a reviewer on it.
- [x] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
