### PR TITLE
[Odin] Fix shutdown not working on unix

### DIFF
--- a/src/odin/server/mod.rs
+++ b/src/odin/server/mod.rs
@@ -1,4 +1,5 @@
 mod install;
+mod process;
 mod shutdown;
 mod startup;
 mod status;

--- a/src/odin/server/process.rs
+++ b/src/odin/server/process.rs
@@ -1,0 +1,32 @@
+use sysinfo::{Process, System, SystemExt};
+
+use crate::constants;
+
+pub struct ServerProcess {
+  system: System,
+}
+
+impl ServerProcess {
+  pub fn new() -> ServerProcess {
+    ServerProcess {
+      system: System::new(),
+    }
+  }
+
+  pub fn get_valheim_processes(&mut self) -> Vec<&Process> {
+    self.system.refresh_processes();
+
+    // Limit search string to 15 characters, as some unix operating systems
+    // cannot handle more then 15 character long process names
+    let valheim_executable_search_name = &constants::VALHEIM_EXECUTABLE_NAME[..15];
+
+    self
+      .system
+      .get_process_by_name(valheim_executable_search_name)
+  }
+
+  pub fn is_running(&mut self) -> bool {
+    let valheim_processes = self.get_valheim_processes();
+    !valheim_processes.is_empty()
+  }
+}

--- a/src/odin/server/shutdown.rs
+++ b/src/odin/server/shutdown.rs
@@ -1,9 +1,9 @@
 use log::{error, info};
-use sysinfo::{ProcessExt, Signal, System, SystemExt};
+use sysinfo::{ProcessExt, Signal};
 
 use std::{thread, time::Duration};
 
-use crate::constants;
+use super::process::ServerProcess;
 
 pub fn blocking_shutdown() {
   send_shutdown_signal();
@@ -12,9 +12,8 @@ pub fn blocking_shutdown() {
 
 pub fn send_shutdown_signal() {
   info!("Scanning for Valheim process");
-  let mut system = System::new();
-  system.refresh_all();
-  let processes = system.get_process_by_name(constants::VALHEIM_EXECUTABLE_NAME);
+  let mut server_process = ServerProcess::new();
+  let processes = server_process.get_valheim_processes();
   if processes.is_empty() {
     info!("Process NOT found!")
   } else {
@@ -34,11 +33,9 @@ pub fn send_shutdown_signal() {
 
 fn wait_for_exit() {
   info!("Waiting for server to completely shutdown...");
-  let mut system = System::new();
+  let mut server_process = ServerProcess::new();
   loop {
-    system.refresh_all();
-    let processes = system.get_process_by_name(constants::VALHEIM_EXECUTABLE_NAME);
-    if processes.is_empty() {
+    if server_process.is_running() {
       break;
     } else {
       // Delay to keep down CPU usage

--- a/src/odin/server/utils.rs
+++ b/src/odin/server/utils.rs
@@ -1,11 +1,5 @@
-use sysinfo::{System, SystemExt};
-
-use crate::constants;
+use super::process::ServerProcess;
 
 pub fn is_running() -> bool {
-  let mut system = System::new();
-  system.refresh_processes();
-  let valheim_processes = system.get_process_by_name(constants::VALHEIM_EXECUTABLE_NAME);
-
-  !valheim_processes.is_empty()
+  ServerProcess::new().is_running()
 }


### PR DESCRIPTION


# Description
Some unix systems limit process names to 15 characters.
This causes odin to not find the valheim process, and therefore
odin incorrectly assumes that the server is not running.

https://docs.rs/sysinfo/0.20.3/sysinfo/trait.ProcessExt.html#tymethod.name

## Contributions

- I collected all Valheim Server process query calls to 'process.rs'
- I limited the search for the valheim server process to the first 15 characters


## Checklist

- [ ] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [x] This PR has a reviewer on it.
- [x] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
