### PR TITLE
[Odin] Fix shutdown procedure finishing too early

### DIFF
--- a/src/odin/server/shutdown.rs
+++ b/src/odin/server/shutdown.rs
@@ -35,7 +35,7 @@ fn wait_for_exit() {
   info!("Waiting for server to completely shutdown...");
   let mut server_process = ServerProcess::new();
   loop {
-    if server_process.is_running() {
+    if !server_process.is_running() {
       break;
     } else {
       // Delay to keep down CPU usage


### PR DESCRIPTION

# Description
PR https://github.com/mbround18/valheim-docker/pull/441 introduced a bug that leads to odin not waiting until the server is shut down completely.

## Contributions

- Fixed missing `!` (not) that got introduced as a typo in https://github.com/mbround18/valheim-docker/pull/441

## Checklist

- [ ] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [ ] This PR has a reviewer on it.
- [x] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
