### PR TITLE
[Bug] Fix default val  when testing with -eq

### DIFF
--- a/src/scripts/auto_backup.sh
+++ b/src/scripts/auto_backup.sh
@@ -15,7 +15,7 @@ else
   if [ "${AUTO_BACKUP_PAUSE_WITH_NO_PLAYERS:=0}" -eq 1 ]; then
     export ADDRESS=${ADDRESS:="127.0.0.1:2457"}
     NUMBER_OF_PLAYERS=$(DEBUG_MODE=false odin status --address="${ADDRESS}" --json | jq -r '.players')
-    if [ "${NUMBER_OF_PLAYERS}" -eq 0 ]; then
+    if [ "${NUMBER_OF_PLAYERS:=0}" -eq 0 ]; then
       log "Skipping backup, no players are online."
       exit 0
     fi
@@ -33,7 +33,7 @@ log "Creating backup..."
 file_name="$(date +"%Y%m%d-%H%M%S")-${1:-"backup"}.tar.gz"
 
 
-if [ -x "$(command -v nice)" ] && [ "${AUTO_BACKUP_NICE_LEVEL:=0}" -ge "1" ] && [ "${AUTO_BACKUP_NICE_LEVEL:=0}" -le "19" ]; then 
+if [ -x "$(command -v nice)" ] && [ "${AUTO_BACKUP_NICE_LEVEL:=0}" -ge "1" ] && [ "${AUTO_BACKUP_NICE_LEVEL:=0}" -le "19" ]; then
   nice -n ${AUTO_BACKUP_NICE_LEVEL} \
     odin backup \
     /home/steam/.config/unity3d/IronGate/Valheim \

--- a/src/scripts/auto_update.sh
+++ b/src/scripts/auto_update.sh
@@ -22,7 +22,7 @@ if odin update --check; then
       if [ "${AUTO_UPDATE_PAUSE_WITH_PLAYERS:=0}" -eq 1 ]; then
         export ADDRESS=${ADDRESS:="127.0.0.1:2457"}
         NUMBER_OF_PLAYERS=$(DEBUG_MODE=false odin status --address="${ADDRESS}" --json | jq -r '.players')
-        if [ "${NUMBER_OF_PLAYERS}" -gt 0 ]; then
+        if [ "${NUMBER_OF_PLAYERS:=0}" -gt 0 ]; then
           log "An update is available. Skipping update, while ${NUMBER_OF_PLAYERS} players online...."
           exit 0
         fi


### PR DESCRIPTION
This PR attempts to fix the following error msg in docker-compose logs:
![image](https://user-images.githubusercontent.com/1074855/165067760-47c1faaa-8377-403e-ba65-836bf2b44826.png)

## Contributions

- Added missing default value in test cases for the variable `NUMBER_OF_PLAYERS`. It seems to be getting a string and -eq test needs to compare integers; Not sure, but this change did away with the error:
```
/home/steam/scripts/auto_backup.sh: line 18: [: : integer expression expected
```

## Checklist

- [x] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [x] This PR has a reviewer on it.
- [ ] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
