### PR TITLE
Update note on requirements for Huginn statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ This repo has a CLI tool called [Odin] in it! It is used for managing the server
 
 > Note on `ADDRESS` this can be set to `127.0.0.1:<your query port>` or `<your public ip>:<your query port>` but does not have to be set. If it is set, it will prevent odin from reaching out to aws ip service from asking for your public IP address. Keep in mind, your query port is +1 of what you set in the `PORT` env variable for your valheim server.
 
+> Another note: your server MUST be public (eg. `PUBLIC=1`) in order for Odin+Huginn to collect and report statistics.
+
 ## Feature Information
 
 ### [BepInEx Support](./docs/bepinex.md)

--- a/src/huginn/README.md
+++ b/src/huginn/README.md
@@ -22,6 +22,8 @@ Huginn is a status server used to check the status of your Valheim server.
 | ADDRESS   | `Your Public IP`      | FALSE    | This setting is used in conjunction with `odin status` and setting this will stop `odin` from trying to fetch your public IP |
 | HTTP_PORT | `anything above 1024` | FALSE    | Setting this will spin up a little http server that provides two endpoints for you to call.                                  |
 
+NOTE: your server MUST be public (eg. `PUBLIC=1`) in order for Odin+Huginn to collect and report statistics.
+
 ### Manually Launching
 
 Simply launch `huginn` in the background with:


### PR DESCRIPTION
# Description

Update docs on requirements for Huginn's endpoints. It's required that `PUBLIC=1` for odin to pull stats from the server. See [this discussion](https://github.com/mbround18/valheim-docker/discussions/626)

I didn't test locally, but no code changes were made.

## Contributions

- I added docs on requiring `PUBLIC=1` to get stats from Huginn because it is an undocumented requirement.

## Checklist

- [x] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [x] This PR has a reviewer on it.
- [x] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
