### PR TITLE
Fix shell profile loading in env.sh

### DIFF
--- a/src/scripts/entrypoint.sh
+++ b/src/scripts/entrypoint.sh
@@ -85,6 +85,7 @@ setup_cron_env() {
     AUTO_BACKUP_ON_SHUTDOWN=${AUTO_BACKUP_ON_SHUTDOWN}
     AUTO_BACKUP_PAUSE_WITH_NO_PLAYERS=${AUTO_BACKUP_PAUSE_WITH_NO_PLAYERS}
     " | \
+    sed "s/'/\\'/g" | \
     while read -r line; do
        if [[ "${line}" == *"="* ]]; then
          CONTENT="export ${line}"

--- a/src/scripts/env.sh
+++ b/src/scripts/env.sh
@@ -4,8 +4,8 @@
 #################################
 
 source /etc/profile
-source "${HOME}/.bash_profile"
-source "${HOME}/.bashrc"
+test "${HOME}/.profile" && source "${HOME}/.profile"
+test "${HOME}/.bashrc" && source "${HOME}/.bashrc"
 
 #################################
 # AUTO GENERATED; DO NOT MODIFY #

--- a/src/scripts/env.sh
+++ b/src/scripts/env.sh
@@ -4,8 +4,8 @@
 #################################
 
 source /etc/profile
-test "${HOME}/.profile" && source "${HOME}/.profile"
-test "${HOME}/.bashrc" && source "${HOME}/.bashrc"
+test -r "${HOME}/.profile" && source "${HOME}/.profile"
+test -r "${HOME}/.bashrc" && source "${HOME}/.bashrc"
 
 #################################
 # AUTO GENERATED; DO NOT MODIFY #


### PR DESCRIPTION
# Description

This fixes warnings/errors trying to load nonexistent shell configs.

## Contributions

- Updated `env.sh` skeleton to fix `/env.sh: line 7: /home/steam/.bash_profile: No such file or directory`
- Updated `entrypoint.sh` to fix quoting issues (i.e. setting `NAME` to `A's B` produces an error specified below)
```
/env.sh: line 20: unexpected EOF while looking for matching `''
```

## Checklist

- [ ] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [ ] This PR has a reviewer on it.
- [ ] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
