### PR TITLE
fix `scheduled_restart` not running due to invalid user

### DIFF
--- a/src/scripts/scheduled_restart.sh
+++ b/src/scripts/scheduled_restart.sh
@@ -2,7 +2,7 @@
 # Cron uses blank env and does not pick up /usr/local/bin files.
 export PATH="/usr/local/bin:$PATH"
 
-if [ "${USER}" != "steam" ]; then
+if [ "$(whoami)" != "steam" ]; then
   echo "You must run this script as the steam user!"
   exit 1
 fi


### PR DESCRIPTION
# Description

## Contributions

- `USER` is not a known environment variable when run via Cron. We switch to using `whoami` instead similar to what is done in `auto_update` and `auto_backup`.

## Checklist

- [ ] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [ ] This PR has a reviewer on it.
- [x] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
