### PR TITLE
Disable auto backup pause on crossplay enabled server

### DIFF
--- a/src/scripts/auto_backup.sh
+++ b/src/scripts/auto_backup.sh
@@ -20,8 +20,8 @@ line() {
 line
 log "Valheim Server - $(date) Backup Process"
 
-if [ "${PUBLIC:=0}" -eq 0 ] && [ "${AUTO_BACKUP_PAUSE_WITH_NO_PLAYERS:=0}" -eq 1 ]; then
-  log "Woah, cannot pause backup process on a server with PUBLIC=0"
+if { [ "${PUBLIC:=0}" -eq 0 ] || [ "${ENABLE_CROSSPLAY:=0}" -eq 1 ]; } && [ "${AUTO_BACKUP_PAUSE_WITH_NO_PLAYERS:=0}" -eq 1 ]; then
+  log "Woah, cannot pause backup process on a private or crossplay enabled server"
   log "This is because we cannot query your server via the Steam API"
 else
   if [ "${AUTO_BACKUP_PAUSE_WITH_NO_PLAYERS:=0}" -eq 1 ]; then


### PR DESCRIPTION
# Description

The behavior of AUTO_BACKUP_PAUSE_WITH_NO_PLAYERS should be additionally negated when cross play is enabled, as the Steam Query port also doesn't return player counts properly in this situation.

This can be later removed when there is a more concrete method implemented for querying player counts.

Fixes #1050.

## Contributions

- Disallow pausing backups on zero player counts when crossplay is enabled

## Checklist

- [ ] I added one or multiple labels which best describes this PR.
- [ ] I have tested the changes locally.
- [ ] This PR has a reviewer on it.
- [ ] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)
