### PR TITLE
Add system command for runtime metadata checks and update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,6 +2406,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "nix",
+ "serde",
  "sysinfo",
  "tracing",
  "tracing-log",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       PASSWORD: "Change Me! Please."
       TZ: "America/Los_Angeles"
       AUTO_UPDATE: 1
-      UPDATE_ON_START: 0
+      UPDATE_ON_STARTUP: 0
       AUTO_UPDATE_SCHEDULE: "0 1 * * *"
       TYPE: Vanilla
     build:

--- a/src/odin/cli.rs
+++ b/src/odin/cli.rs
@@ -171,6 +171,17 @@ pub enum Commands {
     #[arg(long)]
     address: Option<String>,
   },
+
+  /// Prints system/runtime metadata (memory, disk, inode, and permission summaries for key paths).
+  System {
+    /// Print output as JSON
+    #[arg(long)]
+    json: bool,
+
+    /// Run startup checks (memory + writable runtime paths) and exit non-zero on failure
+    #[arg(long)]
+    check: bool,
+  },
   /// Prints out information about Odin
   About,
 

--- a/src/odin/commands/mod.rs
+++ b/src/odin/commands/mod.rs
@@ -8,4 +8,5 @@ pub mod notify;
 pub mod start;
 pub mod status;
 pub mod stop;
+pub mod system;
 pub mod update;

--- a/src/odin/commands/system.rs
+++ b/src/odin/commands/system.rs
@@ -1,0 +1,454 @@
+use crate::utils::common_paths::{game_directory, log_directory, mods_directory, saves_directory};
+use serde::Serialize;
+use shared::system::{
+  collect_system_metrics, format_perm_summary, fs_usage_for, perm_summary_for, FsUsage,
+  PermSummary, SystemMetrics,
+};
+use std::env;
+use std::path::Path;
+
+const GIB: u64 = 1024 * 1024 * 1024;
+const MIB: u64 = 1024 * 1024;
+const MIN_MEMORY_BYTES: u64 = 2 * GIB;
+const WARN_AVAILABLE_BYTES: u64 = 5 * GIB;
+const WARN_USED_PERCENT: f64 = 85.0;
+const WARN_INODES_USED_PERCENT: f64 = 85.0;
+const EXIT_SYSTEM_CHECK_FAILED: i32 = 12;
+
+#[derive(Debug, Serialize)]
+struct SystemReport {
+  system: SystemMetrics,
+  paths: Vec<PathObservation>,
+  checks: Option<SystemChecks>,
+}
+
+#[derive(Debug, Serialize)]
+struct PathObservation {
+  label: &'static str,
+  path: String,
+  exists: bool,
+  filesystem: Option<FsUsage>,
+  permissions: Option<PermSummary>,
+}
+
+#[derive(Debug, Serialize)]
+struct SystemChecks {
+  passed: bool,
+  memory: MemoryCheck,
+  storage: StorageCheck,
+  warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct MemoryCheck {
+  passed: bool,
+  min_total_bytes: u64,
+  total_bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct StorageCheck {
+  passed: bool,
+  paths: Vec<PathCheck>,
+}
+
+#[derive(Debug, Serialize)]
+struct PathCheck {
+  label: &'static str,
+  path: String,
+  create_if_missing: bool,
+  create_attempted: bool,
+  create_succeeded: bool,
+  exists: bool,
+  is_dir: bool,
+  writable: bool,
+  passed: bool,
+  error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct RuntimePathSpec {
+  label: &'static str,
+  path: String,
+  create_if_missing: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+struct PathPreparation {
+  create_attempted: bool,
+  create_succeeded: bool,
+  error: Option<String>,
+}
+
+pub fn invoke(output_json: bool, run_check: bool) {
+  let report = build_report(run_check);
+
+  if output_json {
+    println!("{}", serde_json::to_string_pretty(&report).unwrap());
+  } else {
+    print_human_report(&report, run_check);
+  }
+
+  if run_check && report.checks.as_ref().is_some_and(|c| !c.passed) {
+    std::process::exit(EXIT_SYSTEM_CHECK_FAILED);
+  }
+}
+
+fn build_report(include_checks: bool) -> SystemReport {
+  let system = collect_system_metrics();
+  let path_specs = runtime_paths();
+  let preparations = if include_checks {
+    prepare_runtime_paths(&path_specs)
+  } else {
+    vec![PathPreparation::default(); path_specs.len()]
+  };
+  let paths = path_specs
+    .iter()
+    .map(|spec| PathObservation {
+      label: spec.label,
+      exists: Path::new(&spec.path).exists(),
+      filesystem: fs_usage_for(&spec.path),
+      permissions: perm_summary_for(&spec.path),
+      path: spec.path.clone(),
+    })
+    .collect::<Vec<_>>();
+
+  let checks = if include_checks {
+    Some(run_checks(&system, &path_specs, &paths, &preparations))
+  } else {
+    None
+  };
+
+  SystemReport {
+    system,
+    paths,
+    checks,
+  }
+}
+
+fn run_checks(
+  system: &SystemMetrics,
+  specs: &[RuntimePathSpec],
+  paths: &[PathObservation],
+  preparations: &[PathPreparation],
+) -> SystemChecks {
+  let memory = MemoryCheck {
+    passed: system.total_memory_bytes >= MIN_MEMORY_BYTES,
+    min_total_bytes: MIN_MEMORY_BYTES,
+    total_bytes: system.total_memory_bytes,
+  };
+
+  let path_checks = paths
+    .iter()
+    .zip(specs.iter())
+    .zip(preparations.iter())
+    .map(|((p, spec), prep)| {
+      let is_dir = p.permissions.as_ref().is_some_and(|perm| perm.is_dir);
+      let writable = p.permissions.as_ref().is_some_and(|perm| perm.can_write);
+      let passed = prep.error.is_none() && p.exists && is_dir && writable;
+      PathCheck {
+        label: spec.label,
+        path: p.path.clone(),
+        create_if_missing: spec.create_if_missing,
+        create_attempted: prep.create_attempted,
+        create_succeeded: prep.create_succeeded,
+        exists: p.exists,
+        is_dir,
+        writable,
+        passed,
+        error: prep.error.clone(),
+      }
+    })
+    .collect::<Vec<_>>();
+
+  let warnings = paths
+    .iter()
+    .filter_map(storage_warning_for)
+    .collect::<Vec<_>>();
+
+  let storage = StorageCheck {
+    passed: path_checks.iter().all(|p| p.passed),
+    paths: path_checks,
+  };
+
+  let passed = memory.passed && storage.passed;
+
+  SystemChecks {
+    passed,
+    memory,
+    storage,
+    warnings,
+  }
+}
+
+fn storage_warning_for(path: &PathObservation) -> Option<String> {
+  let fs = path.filesystem.as_ref()?;
+
+  if fs.available_bytes < WARN_AVAILABLE_BYTES {
+    return Some(format!(
+      "Low available space on {}: {} available",
+      fs.path,
+      human_bytes(fs.available_bytes)
+    ));
+  }
+
+  if fs.used_percent >= WARN_USED_PERCENT {
+    return Some(format!(
+      "High disk usage on {}: {:.1}% used",
+      fs.path, fs.used_percent
+    ));
+  }
+
+  if fs.inodes_total > 0 && fs.inodes_used_percent >= WARN_INODES_USED_PERCENT {
+    return Some(format!(
+      "High inode usage on {}: {:.1}% used",
+      fs.path, fs.inodes_used_percent
+    ));
+  }
+
+  None
+}
+
+fn runtime_paths() -> Vec<RuntimePathSpec> {
+  let home = env::var("HOME").unwrap_or_else(|_| String::from("/home/steam"));
+  let game = game_directory();
+  let saves = saves_directory();
+  let mods = mods_directory();
+  let logs = env::var("LOG_LOCATION").unwrap_or_else(|_| log_directory());
+  let backups = env::var("BACKUP_LOCATION").unwrap_or_else(|_| format!("{}/backups", game));
+
+  let candidates = vec![
+    RuntimePathSpec {
+      label: "home",
+      path: home,
+      create_if_missing: false,
+    },
+    RuntimePathSpec {
+      label: "game",
+      path: game.clone(),
+      create_if_missing: true,
+    },
+    RuntimePathSpec {
+      label: "saves",
+      path: saves,
+      create_if_missing: true,
+    },
+    RuntimePathSpec {
+      label: "mods",
+      path: mods,
+      create_if_missing: true,
+    },
+    RuntimePathSpec {
+      label: "backups",
+      path: backups,
+      create_if_missing: true,
+    },
+    RuntimePathSpec {
+      label: "logs",
+      path: logs,
+      create_if_missing: true,
+    },
+    RuntimePathSpec {
+      label: "tmp",
+      path: String::from("/tmp"),
+      create_if_missing: false,
+    },
+  ];
+
+  let mut paths = Vec::new();
+  for spec in candidates {
+    if !paths
+      .iter()
+      .any(|existing: &RuntimePathSpec| existing.path == spec.path)
+    {
+      paths.push(spec);
+    }
+  }
+  paths
+}
+
+fn prepare_runtime_paths(specs: &[RuntimePathSpec]) -> Vec<PathPreparation> {
+  specs.iter().map(prepare_runtime_path).collect()
+}
+
+fn prepare_runtime_path(spec: &RuntimePathSpec) -> PathPreparation {
+  let path = Path::new(&spec.path);
+
+  if path.exists() {
+    if !path.is_dir() {
+      return PathPreparation {
+        error: Some(String::from("Path exists but is not a directory")),
+        ..PathPreparation::default()
+      };
+    }
+    return PathPreparation::default();
+  }
+
+  if !spec.create_if_missing {
+    return PathPreparation {
+      error: Some(String::from("Path does not exist")),
+      ..PathPreparation::default()
+    };
+  }
+
+  let mut prep = PathPreparation {
+    create_attempted: true,
+    ..PathPreparation::default()
+  };
+
+  match std::fs::create_dir_all(path) {
+    Ok(_) => {
+      prep.create_succeeded = true;
+    }
+    Err(e) => {
+      prep.error = Some(format!("Failed to create directory recursively: {}", e));
+    }
+  }
+
+  prep
+}
+
+fn print_human_report(report: &SystemReport, include_checks: bool) {
+  let s = &report.system;
+  let used_disk = s.total_disk_bytes.saturating_sub(s.available_disk_bytes);
+  let disk_used_pct = if s.total_disk_bytes > 0 {
+    used_disk as f64 / s.total_disk_bytes as f64 * 100.0
+  } else {
+    0.0
+  };
+  let mem_used_pct = percent(s.used_memory_bytes, s.total_memory_bytes);
+  let swap_used_pct = percent(s.used_swap_bytes, s.total_swap_bytes);
+
+  println!("System:");
+  println!(
+    "  Memory: {} used / {} total ({:.1}%)",
+    human_bytes(s.used_memory_bytes),
+    human_bytes(s.total_memory_bytes),
+    mem_used_pct
+  );
+  println!(
+    "  Swap:   {} used / {} total ({:.1}%)",
+    human_bytes(s.used_swap_bytes),
+    human_bytes(s.total_swap_bytes),
+    swap_used_pct
+  );
+  println!("  CPUs:   {} logical", s.cpu_num_logical);
+  println!(
+    "  Load:   {:.2} {:.2} {:.2}",
+    s.load_average_one, s.load_average_five, s.load_average_fifteen
+  );
+  println!(
+    "  Disk:   {} used / {} total ({:.1}%), {} available (aggregate)",
+    human_bytes(used_disk),
+    human_bytes(s.total_disk_bytes),
+    disk_used_pct,
+    human_bytes(s.available_disk_bytes)
+  );
+
+  println!("Paths:");
+  for p in &report.paths {
+    println!("  {} ({})", p.path, p.label);
+
+    match &p.filesystem {
+      Some(fs) => println!(
+        "    FS:    used={} ({:.1}%), avail={}, total={}, inodes={:.1}% used",
+        human_bytes(fs.used_bytes),
+        fs.used_percent,
+        human_bytes(fs.available_bytes),
+        human_bytes(fs.total_bytes),
+        fs.inodes_used_percent
+      ),
+      None => println!("    FS:    unavailable"),
+    }
+
+    match &p.permissions {
+      Some(perm) => println!("    {}", format_perm_summary(perm)),
+      None => println!("    Perms: unavailable"),
+    }
+  }
+
+  if include_checks {
+    if let Some(checks) = &report.checks {
+      println!("Checks:");
+      println!(
+        "  Memory >= {}: {} (detected {})",
+        human_bytes(checks.memory.min_total_bytes),
+        if checks.memory.passed { "PASS" } else { "FAIL" },
+        human_bytes(checks.memory.total_bytes)
+      );
+      println!(
+        "  Storage paths writable: {}",
+        if checks.storage.passed {
+          "PASS"
+        } else {
+          "FAIL"
+        }
+      );
+      for p in &checks.storage.paths {
+        println!(
+          "    {} ({}) -> exists={}, dir={}, writable={}, create_if_missing={}, create_attempted={}, create_succeeded={}, result={}",
+          p.path,
+          p.label,
+          yes_no(p.exists),
+          yes_no(p.is_dir),
+          yes_no(p.writable),
+          yes_no(p.create_if_missing),
+          yes_no(p.create_attempted),
+          yes_no(p.create_succeeded),
+          if p.passed { "PASS" } else { "FAIL" }
+        );
+        if let Some(error) = &p.error {
+          println!("      error: {}", error);
+        }
+      }
+
+      if checks.warnings.is_empty() {
+        println!("  Warnings: none");
+      } else {
+        println!("  Warnings:");
+        for w in &checks.warnings {
+          println!("    - {}", w);
+        }
+      }
+
+      if checks.storage.paths.iter().any(|p| !p.passed) {
+        println!("  Remediation:");
+        println!("    This container runs rootless and cannot repair host bind mount ownership.");
+        println!("    Ensure the host directories mapped to failed paths are writable by the container user.");
+        println!("    Example: sudo chown -R <uid>:<gid> <host-path>");
+        println!("    Example: sudo chmod -R u+rwX,g+rwX <host-path>");
+        println!("    Also ensure Compose uses a matching user: `user: \"UID:GID\"`.");
+      }
+
+      println!("  Overall: {}", if checks.passed { "PASS" } else { "FAIL" });
+    }
+  }
+}
+
+fn percent(used: u64, total: u64) -> f64 {
+  if total == 0 {
+    0.0
+  } else {
+    used as f64 / total as f64 * 100.0
+  }
+}
+
+fn human_bytes(bytes: u64) -> String {
+  if bytes >= GIB {
+    format!("{:.1} GiB", bytes as f64 / GIB as f64)
+  } else if bytes >= MIB {
+    format!("{:.1} MiB", bytes as f64 / MIB as f64)
+  } else if bytes >= 1024 {
+    format!("{:.1} KiB", bytes as f64 / 1024.0)
+  } else {
+    format!("{} B", bytes)
+  }
+}
+
+fn yes_no(value: bool) -> &'static str {
+  if value {
+    "yes"
+  } else {
+    "no"
+  }
+}

--- a/src/odin/main.rs
+++ b/src/odin/main.rs
@@ -134,6 +134,7 @@ async fn handle_commands(cli: Cli) {
       local,
       address,
     } => commands::status::invoke(json, local, address),
+    Commands::System { json, check } => commands::system::invoke(json, check),
     Commands::About => about(env!("GIT_HASH")),
     Commands::Logs { lines, watch } => commands::logs::invoke(lines, watch).await,
   }

--- a/src/odin/server/install.rs
+++ b/src/odin/server/install.rs
@@ -56,6 +56,79 @@ fn add_additional_args(args: &mut Vec<String>) {
   }
 }
 
+fn build_steamcmd_install_args(
+  app_id: i64,
+  install_dir: &str,
+  beta_cfg: &BetaConfig,
+  include_validate: bool,
+) -> Vec<String> {
+  let login = "+login anonymous".to_string();
+  let force_install_dir = format!("+force_install_dir {}", install_dir);
+
+  // Build SteamCMD args with order:
+  // 1) +@ control vars  2) +force_install_dir  3) +login  4) optional verbose  5) +app_update {id} [beta flags] [validate]
+  let mut args = vec![
+    String::from("+@NoPromptForPassword"),
+    String::from("1"),
+    String::from("+@ShutdownOnFailedCommand"),
+    String::from("1"),
+    String::from("+@sSteamCmdForcePlatformType"),
+    String::from("linux"),
+    String::from("+@sSteamCmdForcePlatformBitness"),
+    String::from("64"),
+    force_install_dir,
+    login,
+  ];
+
+  if environment::is_env_var_truthy_with_default("DEBUG_MODE", false) {
+    args.push(String::from("verbose"));
+  }
+
+  args.push(compose_app_update_arg(app_id, beta_cfg, include_validate));
+
+  add_additional_args(&mut args);
+
+  // remove the call to steamcmd from args to avoid duplication
+  args.retain(|arg| arg != "/usr/bin/steamcmd");
+
+  let args = flatten_args(args);
+  parse_command_args(args)
+}
+
+fn auto_repair_steamapps_on_update_exit8_enabled() -> bool {
+  environment::is_env_var_truthy_with_default("AUTO_REPAIR_STEAMAPPS_ON_UPDATE_EXIT8", true)
+}
+
+fn should_attempt_steamapps_repair_after_update(result: &io::Result<ExitStatus>) -> bool {
+  if !auto_repair_steamapps_on_update_exit8_enabled() {
+    return false;
+  }
+  matches!(result, Ok(status) if !status.success() && status.code() == Some(8))
+}
+
+fn reset_install_steamapps_dir(install_dir: &str) -> Result<(), String> {
+  let steamapps_dir = Path::new(install_dir).join("steamapps");
+  if !steamapps_dir.exists() {
+    info!(
+      "SteamCMD recovery: steamapps dir not present, nothing to delete: {}",
+      steamapps_dir.display()
+    );
+    return Ok(());
+  }
+
+  info!(
+    "SteamCMD recovery: deleting steamapps dir before retry: {}",
+    steamapps_dir.display()
+  );
+  remove_path_cautious(&steamapps_dir).map_err(|e| {
+    format!(
+      "failed to delete steamapps dir {}: {}",
+      steamapps_dir.display(),
+      e
+    )
+  })
+}
+
 pub fn install(app_id: i64) -> io::Result<ExitStatus> {
   let staged_install = staged_updates_enabled();
   let live_install_dir = get_working_dir();
@@ -112,51 +185,41 @@ pub fn install(app_id: i64) -> io::Result<ExitStatus> {
   } else {
     info!("Installing using default/stable branch");
   }
+  let validate_on_install =
+    environment::is_env_var_truthy_with_default("VALIDATE_ON_INSTALL", true);
 
   info!("Installing {} to {}", app_id, install_dir);
-  let login = "+login anonymous".to_string();
-  let force_install_dir = format!("+force_install_dir {}", install_dir);
-  // Build SteamCMD args with order:
-  // 1) +@ control vars  2) +force_install_dir  3) +login  4) optional verbose  5) +app_update {id} [beta flags] [validate]
-  let mut args = vec![
-    // +@ controls first
-    String::from("+@NoPromptForPassword"),
-    String::from("1"),
-    String::from("+@ShutdownOnFailedCommand"),
-    String::from("1"),
-    String::from("+@sSteamCmdForcePlatformType"),
-    String::from("linux"),
-    String::from("+@sSteamCmdForcePlatformBitness"),
-    String::from("64"),
-    // then force install dir and login
-    force_install_dir,
-    login,
-  ];
+  info!("SteamCMD phase: update");
+  let update_args = build_steamcmd_install_args(app_id, &install_dir, &beta_cfg, false);
+  let mut steamcmd_phase = "update";
+  let mut result = run_with_retries(&update_args);
 
-  if environment::is_env_var_truthy_with_default("DEBUG_MODE", false) {
-    args.push(String::from("verbose"));
+  if should_attempt_steamapps_repair_after_update(&result) {
+    warn!(
+      "steamcmd update exited with code 8. This commonly corresponds to app state issues (e.g. state 0x6). \
+Attempting one-time recovery by deleting the install steamapps folder and retrying update."
+    );
+    match reset_install_steamapps_dir(&install_dir) {
+      Ok(()) => {
+        info!("SteamCMD phase: update (recovery retry after steamapps reset)");
+        result = run_with_retries(&update_args);
+      }
+      Err(e) => {
+        error!("SteamCMD recovery failed before retry: {}", e);
+      }
+    }
   }
 
-  // Compose +app_update with beta flags and optional validate as trailing args
-  let app_update = compose_app_update_arg(
-    app_id,
-    &beta_cfg,
-    environment::is_env_var_truthy_with_default("VALIDATE_ON_INSTALL", true),
-  );
-  args.push(app_update);
-
-  // Append any additional raw args, if provided
-  // Append any additional raw args, if provided (handled consistently with helper)
-  add_additional_args(&mut args);
-
-  // remove the call to steamccmd from args to avoid duplication
-  args.retain(|arg| arg != "/usr/bin/steamcmd");
-
-  // for args if it has a space, reduce and append it so its a seperate arg
-  args = flatten_args(args);
-  args = parse_command_args(args);
-
-  let mut result = run_with_retries(&args);
+  if matches!(&result, Ok(status) if status.success()) {
+    if validate_on_install {
+      info!("SteamCMD phase: verify (validate)");
+      steamcmd_phase = "verify";
+      let verify_args = build_steamcmd_install_args(app_id, &install_dir, &beta_cfg, true);
+      result = run_with_retries(&verify_args);
+    } else {
+      debug!("Skipping separate SteamCMD verify step: VALIDATE_ON_INSTALL=0");
+    }
+  }
 
   if staged_install {
     match &result {
@@ -188,10 +251,11 @@ pub fn install(app_id: i64) -> io::Result<ExitStatus> {
 
   // If the install failed, collect diagnostics to help identify issues (e.g., low disk space)
   if let Err(ref e) = result {
-    error!("steamcmd execution error: {e}");
+    error!("steamcmd {steamcmd_phase} step execution error: {e}");
     collect_install_diagnostics(None);
   } else if let Ok(ref status) = result {
     if !status.success() {
+      error!("steamcmd {steamcmd_phase} step failed");
       collect_install_diagnostics(status.code());
     }
   }

--- a/src/odin/utils/steamcmd_args.rs
+++ b/src/odin/utils/steamcmd_args.rs
@@ -1,4 +1,3 @@
-use log::debug;
 use std::env;
 
 use crate::utils::environment;
@@ -43,7 +42,7 @@ impl BetaConfig {
   }
 }
 
-/// Build the +app_update ... segment including any beta flags and validate toggle.
+/// Build the +app_update ... segment including any beta flags and optional validate toggle.
 pub fn compose_app_update_arg(app_id: i64, beta: &BetaConfig, do_validate: bool) -> String {
   let mut app_update = format!("+app_update {app_id}");
   if beta.beta_in_effect() {
@@ -54,8 +53,6 @@ pub fn compose_app_update_arg(app_id: i64, beta: &BetaConfig, do_validate: bool)
   }
   if do_validate {
     app_update.push_str(" validate");
-  } else {
-    debug!("Skipping SteamCMD validate: VALIDATE_ON_INSTALL=0");
   }
   app_update
 }

--- a/src/scripts/entrypoint.sh
+++ b/src/scripts/entrypoint.sh
@@ -24,30 +24,6 @@ runtime_user_label() {
   fi
 }
 
-# Run a command with elevated privileges when possible.
-# If elevation is not available (common in explicit rootless user mode),
-# return non-zero and let the caller decide whether to skip.
-run_privileged() {
-  if [ "$(id -u)" -eq 0 ]; then
-    "$@"
-    return $?
-  fi
-
-  if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
-    sudo "$@"
-    return $?
-  fi
-
-  return 1
-}
-
-# Best-effort wrapper for privileged commands.
-run_privileged_or_warn() {
-  if ! run_privileged "$@"; then
-    log "Skipping privileged command (no sudo/root): $*"
-  fi
-}
-
 # Function to check and log the current user and steam user's ID and group ID
 check_user_and_group() {
   log "Runtime user: $(runtime_user_label)"
@@ -76,13 +52,13 @@ setup_environment() {
   export ODIN_CONFIG_FILE="${ODIN_CONFIG_FILE:-"${GAME_LOCATION}/config.json"}"
   export ODIN_DISCORD_FILE="${ODIN_DISCORD_FILE:-"${GAME_LOCATION}/discord.json"}"
 
-  # Set timezone (best effort). In rootless mode, /etc may be read-only.
+  # Rootless mode: do not attempt to mutate /etc. The TZ env var is still exported.
   if [ -f "/usr/share/zoneinfo/$TZ" ]; then
-    run_privileged_or_warn ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime
+    log "Rootless mode: skipping /etc/localtime update (TZ=${TZ})"
   else
-    log "Timezone '$TZ' not found under /usr/share/zoneinfo; skipping /etc/localtime update"
+    log "Timezone '$TZ' not found under /usr/share/zoneinfo; leaving timezone files unchanged"
   fi
-  run_privileged_or_warn sh -c 'printf "%s\n" "$1" > /etc/timezone' sh "$TZ"
+  log "Rootless mode: skipping /etc/timezone update"
 }
 
 # Function to safely shut down the server
@@ -93,61 +69,6 @@ clean_up() {
 # Trap signals for safe shutdown
 trap clean_up INT TERM
 
-# Function to create directories with specified ownership and permissions
-create_dir_with_ownership() {
-  local user=$1
-  local group=$2
-  local dir=$3
-
-  mkdir -p "${dir}"
-  run_privileged_or_warn chown -R "${user}:${group}" "${dir}"
-  run_privileged_or_warn chmod -R ug+rw "${dir}"
-}
-
-# Function to set up the filesystem, ensuring correct ownership and permissions
-setup_filesystem() {
-  log "Setting up file systems"
-
-  run_privileged_or_warn chown -R "$PUID:$PGID" "$HOME"
-  run_privileged_or_warn chmod -R ug+rwx "$HOME"
-  # Ensure /tmp remains writable for steamcmd/work files even when host-mounted.
-  run_privileged_or_warn mkdir -p /tmp
-  run_privileged_or_warn chown root:root /tmp
-  run_privileged_or_warn chmod 1777 /tmp
-
-  create_dir_with_ownership "$PUID" "$PGID" "$SAVE_LOCATION"
-  create_dir_with_ownership "$PUID" "$PGID" "$MODS_LOCATION"
-  create_dir_with_ownership "$PUID" "$PGID" "$BACKUP_LOCATION"
-  create_dir_with_ownership "$PUID" "$PGID" "$GAME_LOCATION"
-  create_dir_with_ownership "$PUID" "$PGID" "$GAME_LOCATION/logs"
-  mkdir -p /home/steam/scripts || log "Could not create /home/steam/scripts without elevated permissions"
-
-  run_privileged_or_warn usermod -d /home/steam steam
-}
-
-# Validate that key runtime paths are writable for the current user.
-validate_runtime_paths() {
-  local path
-  for path in "$HOME" "$GAME_LOCATION" "$SAVE_LOCATION" "$MODS_LOCATION" "$BACKUP_LOCATION" /tmp; do
-    mkdir -p "$path" 2>/dev/null || true
-    if [ ! -w "$path" ]; then
-      log "Path is not writable by runtime user: $path"
-      log "If you run with a custom user, ensure mounted volumes and /home/steam are writable by uid:gid $(id -u):$(id -g)"
-    fi
-  done
-}
-
-# Function to check if the system has sufficient memory
-check_memory() {
-  local total_memory
-  total_memory=$(free -h | awk '/^Mem:/ {print $2}' | tr -d 'G')
-  if (($(echo "$total_memory < 2" | bc -l))); then
-  log "Your system has less than 2GB of RAM! Valheim might not run on your system."
-  else
-    log "Total memory: ${total_memory} GB"
-  fi
-}
-
 # Main script execution
 log "Valheim Server - $(date)"
 log "Initializing your container..."
@@ -155,21 +76,12 @@ log "Initializing your container..."
 # Check current user and steam user details
 check_user_and_group
 
-# Default ownership targets to current runtime UID/GID when not explicitly set.
-export PUID="${PUID:-$(id -u)}"
-export PGID="${PGID:-$(id -g)}"
-
 # Set up environment
 setup_environment
 
-# Check system memory
-check_memory
-
-# Set up the filesystem
-setup_filesystem
-
-# Validate runtime write access in rootless mode
-validate_runtime_paths
+# Validate system/runtime requirements in Odin (creates required dirs, checks memory + path writability)
+log "Running system checks..."
+odin system --check || exit 1
 
 # Navigate to the Valheim game directory
 log "Navigating to steam home..."

--- a/src/scripts/start_valheim.sh
+++ b/src/scripts/start_valheim.sh
@@ -61,11 +61,9 @@ install_bepinex() {
 # Navigate to the Valheim directory or exit if it fails
 cd /home/steam/valheim
 
-# Default to runtime UID/GID when env vars are not explicitly set
-export PUID="${PUID:-$(id -u)}"
-export PGID="${PGID:-$(id -g)}"
-STEAM_UID="${PUID}"
-STEAM_GID="${PGID}"
+# Rootless runtime identity (used for logging/guardrails)
+STEAM_UID="$(id -u)"
+STEAM_GID="$(id -g)"
 
 # Source utility scripts if they exist
 [ -f "/home/steam/scripts/utils.sh" ] && source "/home/steam/scripts/utils.sh"
@@ -80,7 +78,7 @@ fi
 
 # Warn if .bashrc is missing
 if [ ! -f "/home/steam/.bashrc" ]; then
-  log "WARNING: You should not run the server without a .bashrc! Please use a non-root user!"
+  log "WARNING: /home/steam/.bashrc is missing; shell profile customizations may not load as expected."
 fi
 
 # Check if webhook URL is provided

--- a/src/shared/Cargo.toml
+++ b/src/shared/Cargo.toml
@@ -13,6 +13,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt"] }
 tracing-log = "0.2.0"
 sysinfo = { version = "0.38.2" }
+serde = { version = "1.0.228", features = ["derive"] }
 nix = { version = "0.31.1", default-features = false, features = [
     "fs",
     "user",

--- a/src/shared/src/system.rs
+++ b/src/shared/src/system.rs
@@ -1,10 +1,11 @@
 use nix::sys::statvfs::statvfs;
 use nix::unistd::{Gid, Uid, getgroups};
+use serde::Serialize;
 use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use sysinfo::{Disks, System};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct SystemMetrics {
   pub total_memory_bytes: u64,
   pub used_memory_bytes: u64,
@@ -53,7 +54,7 @@ pub fn collect_system_metrics() -> SystemMetrics {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct FsUsage {
   pub path: String,
   pub total_bytes: u64,
@@ -100,7 +101,7 @@ pub fn fs_usage_for<P: AsRef<Path>>(path: P) -> Option<FsUsage> {
   })
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct PermSummary {
   pub path: String,
   pub owner_uid: u32,


### PR DESCRIPTION
- Introduced a new `System` command to print system/runtime metadata, including memory, disk, and permission summaries.
- Updated `Cargo.lock` to include `serde` for serialization.
- Modified `docker-compose.yml` to correct environment variable name from `UPDATE_ON_START` to `UPDATE_ON_STARTUP`.
- Refactored `main.rs` to invoke the new `System` command.
- Added `system.rs` file to handle system checks and reporting.
- Updated `install.rs` to improve SteamCMD installation arguments and error handling.
- Cleaned up `entrypoint.sh` by removing unnecessary privileged command functions and added system checks.
- Updated `start_valheim.sh` to use runtime UID/GID directly for logging.
