### PR TITLE
docs: remove explicit docker compose version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,6 @@ For a complete walkthrough, see [Rootless Design Guide](./docs/tutorials/rootles
 > This is a basic example of a Docker Compose file. You can apply any of the variables above to the `environment` section below but be sure to follow each variable's description notes!
 
 ```yaml
-version: "3"
 services:
   valheim:
     image: mbround18/valheim:3
@@ -278,7 +277,6 @@ services:
 ### Everything but the Kitchen Sink
 
 ```yaml
-version: "3"
 services:
   valheim:
     image: mbround18/valheim:3

--- a/docs/tutorials/getting_started_with_mods.md
+++ b/docs/tutorials/getting_started_with_mods.md
@@ -27,7 +27,6 @@ If you do not wish to install additional mods, you can skip this step. Otherwise
 Example configuration:
 
 ```yaml
-version: "3"
 services:
   valheim:
     image: mbround18/valheim:3
@@ -50,7 +49,6 @@ Specify mods by providing their URLs. Ensure that each URL is followed by a newl
 Example configuration:
 
 ```yaml
-version: "3"
 services:
   valheim:
     image: mbround18/valheim:3

--- a/docs/tutorials/group_file_system_access.md
+++ b/docs/tutorials/group_file_system_access.md
@@ -50,7 +50,6 @@ For the most reliable experience, we recommend explicitly setting the **user dir
 Open your `docker-compose.yml` file in a text editor and modify it as follows:
 
 ```yaml
-version: "3"
 services:
   valheim:
     image: mbround18/valheim:3

--- a/docs/tutorials/valheimplus_installation.md
+++ b/docs/tutorials/valheimplus_installation.md
@@ -7,7 +7,6 @@ ValheimPlus is a comprehensive mod that enhances Valheim with numerous quality-o
 To install ValheimPlus, set your Docker environment variables like this:
 
 ```yaml
-version: "3"
 services:
   valheim:
     image: mbround18/valheim:3


### PR DESCRIPTION
# Description

The top level version property is deprecated:
https://docs.docker.com/reference/compose-file/legacy-versions/

A warning is emitted when you have it:
> WARN[0000] /home/jterrace/valheim-server/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
