### PR TITLE
Wait and retry when Thunderstore limits mod requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "odin"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "a2s",
  "anyhow",

--- a/docs/tutorials/getting_started_with_mods.md
+++ b/docs/tutorials/getting_started_with_mods.md
@@ -129,3 +129,12 @@ environment:
   - TYPE=BepInEx
   - MODS=https://github.com/Grantapher/ValheimPlus/releases/download/0.9.16.2/ValheimPlus.dll
 ```
+
+## Thunderstore rate limits
+
+Odin spaces mod requests to `thunderstore.io` and its subdomains at least one second
+apart. If Thunderstore returns `429 Too Many Requests`, new Thunderstore requests
+pause for its `Retry-After` time.
+Without a valid retry time, Odin waits 60, 120, then 240 seconds before retrying.
+After three unsuccessful retries, installation stops with an error. Allow the
+cooldown to finish instead of repeatedly restarting the container.

--- a/src/odin/Cargo.toml
+++ b/src/odin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odin"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["mbround18"]
 edition = "2021"
 license = "BSD-3-Clause License"

--- a/src/odin/mods/valheim_mod.rs
+++ b/src/odin/mods/valheim_mod.rs
@@ -1,7 +1,7 @@
 use crate::errors::ValheimModError;
 use crate::mods::manifest::Manifest;
 use crate::utils::normalize_paths::normalize_paths;
-use crate::utils::thunderstore_http::send;
+use crate::utils::thunderstore_http::{client_builder, send};
 use crate::utils::{is_valid_url, parse_mod_string};
 use crate::{
   constants::SUPPORTED_FILE_TYPES,
@@ -10,7 +10,6 @@ use crate::{
 use fs_extra::dir;
 use fs_extra::dir::CopyOptions;
 use log::{debug, error, info, warn};
-use reqwest::Client;
 use reqwest::Url;
 use sha2::{Digest, Sha256};
 use std::convert::TryFrom;
@@ -73,7 +72,7 @@ async fn thunderstore_list_versions(
     None
   }
 
-  let client = reqwest::Client::builder()
+  let client = client_builder()
     .timeout(Duration::from_secs(10))
     .user_agent("odin-valheim-docker/1.0 (+https://github.com/mbround18/valheim-docker)")
     .build()
@@ -397,7 +396,11 @@ impl ValheimMod {
 
     let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_WORKERS));
     let url = Arc::new(url.to_string());
-    let client = Arc::new(Client::new());
+    let client = Arc::new(
+      client_builder()
+        .build()
+        .map_err(|e| ValheimModError::DownloadError(e.to_string()))?,
+    );
     // Shared writable handle — write_at uses pwrite64 so concurrent non-overlapping
     // writes are safe without any additional locking.
     let file = Arc::new(
@@ -532,7 +535,9 @@ impl ValheimMod {
 
     // Perform request (to resolve redirects and final file type if needed).
     let parsed_url = Url::parse(&self.url).map_err(|_| ValheimModError::InvalidUrl)?;
-    let client = Client::new();
+    let client = client_builder()
+      .build()
+      .map_err(|e| ValheimModError::DownloadError(e.to_string()))?;
     debug!("⬇️  Downloading from: {}", self.url);
     let response = send(client.get(parsed_url), &self.url)
       .await?

--- a/src/odin/mods/valheim_mod.rs
+++ b/src/odin/mods/valheim_mod.rs
@@ -1,7 +1,8 @@
 use crate::errors::ValheimModError;
 use crate::mods::manifest::Manifest;
 use crate::utils::normalize_paths::normalize_paths;
-use crate::utils::{is_valid_url, parse_mod_string, with_thunderstore_auth};
+use crate::utils::thunderstore_http::send;
+use crate::utils::{is_valid_url, parse_mod_string};
 use crate::{
   constants::SUPPORTED_FILE_TYPES,
   utils::{common_paths, get_md5_hash, parse_file_name, url_parse_file_type},
@@ -100,8 +101,13 @@ async fn thunderstore_list_versions(
   for url in endpoints {
     for attempt in 1..=2 {
       log::debug!("Thunderstore version query attempt {}: {}", attempt, url);
-      match with_thunderstore_auth(client.get(&url), &url).send().await {
+      match send(client.get(&url), &url).await {
         Ok(resp) => {
+          if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(ValheimModError::DownloadError(
+              "Thunderstore rate limit persisted after retries; try again later".to_string(),
+            ));
+          }
           if !resp.status().is_success() {
             last_err = Some(format!("status {} for {}", resp.status(), url));
             continue;
@@ -127,7 +133,7 @@ async fn thunderstore_list_versions(
         }
       }
       // brief backoff before next attempt
-      std::thread::sleep(Duration::from_millis(500));
+      tokio::time::sleep(Duration::from_millis(500)).await;
     }
   }
 
@@ -136,10 +142,7 @@ async fn thunderstore_list_versions(
     "https://thunderstore.io/c/valheim/p/{}/{}/",
     namespace, name
   );
-  match with_thunderstore_auth(client.get(&page_url), &page_url)
-    .send()
-    .await
-  {
+  match send(client.get(&page_url), &page_url).await {
     Ok(resp) if resp.status().is_success() => match resp.text().await {
       Ok(html) => {
         let needle = format!("/package/download/{}/{}/", namespace, name);
@@ -417,11 +420,14 @@ impl ValheimMod {
 
       join_set.spawn(async move {
         let _permit = sem.acquire().await.unwrap();
-        let resp = with_thunderstore_auth(client.get(url.as_str()), &url)
-          .header("Range", format!("bytes={}-{}", start_byte, end_byte))
-          .send()
-          .await
-          .map_err(|e| ValheimModError::DownloadError(format!("chunk {i}: {e}")))?;
+        let resp = send(
+          client
+            .get(url.as_str())
+            .header("Range", format!("bytes={}-{}", start_byte, end_byte)),
+          &url,
+        )
+        .await
+        .map_err(|e| ValheimModError::DownloadError(format!("chunk {i}: {e}")))?;
 
         // 206 Partial Content is expected; 200 is tolerated (full body served).
         if resp.status() != reqwest::StatusCode::PARTIAL_CONTENT && !resp.status().is_success() {
@@ -468,25 +474,6 @@ impl ValheimMod {
   /// Download: Downloads the mod ZIP from the URL into the staging location.
   pub async fn download(&mut self) -> Result<(), ValheimModError> {
     debug!("Initializing mod download...");
-    // For Thunderstore download URLs, validate upfront that the URL isn't 404 to give fast feedback.
-    if Self::is_thunderstore_download_url(&self.url) {
-      let client = Client::new();
-      match with_thunderstore_auth(client.head(&self.url), &self.url)
-        .send()
-        .await
-      {
-        Ok(resp) => {
-          let status = resp.status();
-          if status.is_client_error() {
-            return Err(ValheimModError::DownloadError(format!(
-              "Thunderstore URL not reachable, status: {}",
-              status
-            )));
-          }
-        }
-        Err(e) => return Err(ValheimModError::DownloadError(e.to_string())),
-      }
-    }
     // Always derive the staging directory from common paths to avoid stale file paths
     let staging_dir: PathBuf = common_paths::mods_staging_directory().into();
     if !staging_dir.exists() {
@@ -547,9 +534,9 @@ impl ValheimMod {
     let parsed_url = Url::parse(&self.url).map_err(|_| ValheimModError::InvalidUrl)?;
     let client = Client::new();
     debug!("⬇️  Downloading from: {}", self.url);
-    let response = with_thunderstore_auth(client.get(parsed_url), &self.url)
-      .send()
-      .await
+    let response = send(client.get(parsed_url), &self.url)
+      .await?
+      .error_for_status()
       .map_err(|e| ValheimModError::DownloadError(e.to_string()))?;
 
     if !SUPPORTED_FILE_TYPES.contains(&self.file_type.as_str()) {
@@ -814,10 +801,6 @@ impl ValheimMod {
     }
   }
 
-  fn is_thunderstore_download_url(url: &str) -> bool {
-    url.contains("thunderstore.io/package/download/")
-  }
-
   /// Async constructor that resolves Thunderstore wildcards.
   pub async fn async_from_url(url: &str) -> Result<Self, ValheimModError> {
     if is_valid_url(url) {
@@ -996,14 +979,6 @@ mod thunderstore_tests {
     let input = "https://example.com/mod.zip".to_string();
     let vm = ValheimMod::try_from(input.clone()).expect("Should construct from URL");
     assert_eq!(vm.url, input);
-  }
-
-  #[tokio::test]
-  async fn detects_thunderstore_download_url() {
-    let turl = "https://thunderstore.io/package/download/Author/Mod/1.2.3/";
-    assert!(ValheimMod::is_thunderstore_download_url(turl));
-    let normal = "https://example.com/path/file.zip";
-    assert!(!ValheimMod::is_thunderstore_download_url(normal));
   }
 
   #[tokio::test]

--- a/src/odin/utils/mod.rs
+++ b/src/odin/utils/mod.rs
@@ -12,6 +12,7 @@ pub mod is_valid_url;
 pub mod normalize_paths;
 pub mod parse_mod_string;
 pub mod thunderstore_auth;
+pub(crate) mod thunderstore_http;
 
 pub use is_valid_url::is_valid_url;
 pub use parse_mod_string::parse_mod_string;

--- a/src/odin/utils/thunderstore_http.rs
+++ b/src/odin/utils/thunderstore_http.rs
@@ -97,6 +97,20 @@ fn is_thunderstore(url: &reqwest::Url) -> bool {
     .is_some_and(|host| host == "thunderstore.io" || host.ends_with(".thunderstore.io"))
 }
 
+fn redirect_referer(
+  previous: &reqwest::Url,
+  next: &reqwest::Url,
+) -> Option<reqwest::header::HeaderValue> {
+  if previous.scheme() == "https" && next.scheme() == "http" {
+    return None;
+  }
+  let mut referer = previous.clone();
+  let _ = referer.set_username("");
+  let _ = referer.set_password(None);
+  referer.set_fragment(None);
+  referer.as_str().parse().ok()
+}
+
 /// Send a mod GET request, pacing and retrying each Thunderstore redirect hop.
 /// Callers must build their client with `client_builder`.
 pub(crate) async fn send(request: RequestBuilder, url: &str) -> Result<Response, ValheimModError> {
@@ -152,6 +166,13 @@ pub(crate) async fn send(request: RequestBuilder, url: &str) -> Result<Response,
       ] {
         request.headers_mut().remove(header);
       }
+    }
+    if let Some(referer) = redirect_referer(request.url(), &next) {
+      request
+        .headers_mut()
+        .insert(reqwest::header::REFERER, referer);
+    } else {
+      request.headers_mut().remove(reqwest::header::REFERER);
     }
     *request.url_mut() = next;
   }
@@ -299,6 +320,10 @@ mod tests {
       .with_status(307)
       .match_header("authorization", mockito::Matcher::Missing)
       .match_header("cookie", mockito::Matcher::Missing)
+      .match_header(
+        "referer",
+        format!("http://thunderstore.io:{port}/origin").as_str(),
+      )
       .with_header("Location", "/final")
       .expect(1)
       .create_async()
@@ -363,5 +388,18 @@ mod tests {
       .to_string()
       .contains("Too many mod download redirects"));
     redirect.assert_async().await;
+  }
+
+  #[test]
+  fn sanitizes_referer_and_omits_it_on_https_downgrades() {
+    let previous =
+      reqwest::Url::parse("https://user:password@thunderstore.io/mod#private").unwrap();
+    let next = reqwest::Url::parse("https://cdn.thunderstore.io/mod.zip").unwrap();
+    assert_eq!(
+      redirect_referer(&previous, &next).unwrap(),
+      "https://thunderstore.io/mod"
+    );
+    let downgrade = reqwest::Url::parse("http://cdn.thunderstore.io/mod.zip").unwrap();
+    assert!(redirect_referer(&previous, &downgrade).is_none());
   }
 }

--- a/src/odin/utils/thunderstore_http.rs
+++ b/src/odin/utils/thunderstore_http.rs
@@ -24,10 +24,10 @@ impl RequestGate {
     }
   }
 
-  // Hold the gate through response headers so another worker cannot miss a new cooldown.
+  // Keep other workers queued through retries so they cannot multiply the retry budget.
   async fn send(&self, request: RequestBuilder) -> Result<Response, ValheimModError> {
+    let mut next = self.next_request.lock().await;
     for attempt in 0..=MAX_RETRIES {
-      let mut next = self.next_request.lock().await;
       if let Some(deadline) = *next {
         sleep_until(deadline).await;
       }
@@ -71,7 +71,6 @@ impl RequestGate {
         attempt + 1,
         MAX_RETRIES
       );
-      // Release the lock before retrying; all queued workers share the deadline.
     }
     unreachable!("the final attempt returns its response")
   }
@@ -87,24 +86,76 @@ fn retry_after(value: &str, now: SystemTime) -> Option<Duration> {
   Some(deadline.duration_since(now).unwrap_or_default())
 }
 
-/// Pace Thunderstore lookups and downloads together, including retries after a 429.
-/// Other hosts keep their existing request behavior.
+/// Redirects are followed by `send` so each Thunderstore hop uses the shared gate.
+pub(crate) fn client_builder() -> reqwest::ClientBuilder {
+  reqwest::Client::builder().redirect(reqwest::redirect::Policy::none())
+}
+
+fn is_thunderstore(url: &reqwest::Url) -> bool {
+  url
+    .host_str()
+    .is_some_and(|host| host == "thunderstore.io" || host.ends_with(".thunderstore.io"))
+}
+
+/// Send a mod GET request, pacing and retrying each Thunderstore redirect hop.
+/// Callers must build their client with `client_builder`.
 pub(crate) async fn send(request: RequestBuilder, url: &str) -> Result<Response, ValheimModError> {
-  let is_thunderstore = reqwest::Url::parse(url).ok().is_some_and(|url| {
-    url
-      .host_str()
-      .is_some_and(|host| host == "thunderstore.io" || host.ends_with(".thunderstore.io"))
-  });
-  if is_thunderstore {
-    THUNDERSTORE
-      .send(with_thunderstore_auth(request, url))
-      .await
-  } else {
-    request
-      .send()
-      .await
-      .map_err(|e| ValheimModError::DownloadError(e.to_string()))
+  let (client, request) = with_thunderstore_auth(request, url).build_split();
+  let mut request = request.map_err(|e| ValheimModError::DownloadError(e.to_string()))?;
+  for hop in 0..=10 {
+    let builder = RequestBuilder::from_parts(
+      client.clone(),
+      request
+        .try_clone()
+        .ok_or_else(|| ValheimModError::DownloadError("Cannot retry mod request".into()))?,
+    );
+    let response = if is_thunderstore(request.url()) {
+      THUNDERSTORE.send(builder).await?
+    } else {
+      builder
+        .send()
+        .await
+        .map_err(|e| ValheimModError::DownloadError(e.to_string()))?
+    };
+    if !matches!(response.status().as_u16(), 301 | 302 | 303 | 307 | 308) {
+      return Ok(response);
+    }
+    let Some(location) = response.headers().get(reqwest::header::LOCATION) else {
+      return Ok(response);
+    };
+    if hop == 10 {
+      return Err(ValheimModError::DownloadError(
+        "Too many mod download redirects".into(),
+      ));
+    }
+    let location = location
+      .to_str()
+      .map_err(|e| ValheimModError::DownloadError(e.to_string()))?;
+    let next = request
+      .url()
+      .join(location)
+      .map_err(|e| ValheimModError::DownloadError(e.to_string()))?;
+    if !matches!(next.scheme(), "http" | "https") {
+      return Err(ValheimModError::DownloadError(
+        "Unsupported mod redirect scheme".into(),
+      ));
+    }
+    if request.url().origin() != next.origin() {
+      // Match reqwest's protection against forwarding credentials to another origin.
+      for header in [
+        "authorization",
+        "cookie",
+        "cookie2",
+        "proxy-authorization",
+        "www-authenticate",
+        "host",
+      ] {
+        request.headers_mut().remove(header);
+      }
+    }
+    *request.url_mut() = next;
   }
+  unreachable!("the last redirect returns an error")
 }
 
 #[cfg(test)]
@@ -159,7 +210,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn stops_after_bounded_retries_with_backoff() {
+  async fn stops_queued_workers_after_bounded_retries_with_backoff() {
     let mut server = mockito::Server::new_async().await;
     let limited = server
       .mock("GET", "/mod")
@@ -170,10 +221,16 @@ mod tests {
       .await;
     let gate = RequestGate::new(Duration::ZERO, Duration::from_millis(10));
     let start = Instant::now();
-    let response = gate
-      .send(reqwest::Client::new().get(format!("{}/mod", server.url())))
-      .await
-      .unwrap();
+    let client = reqwest::Client::new();
+    let url = format!("{}/mod", server.url());
+    // Like the installer, cancel the other workers when the first request fails.
+    let response = tokio::select! {
+      result = gate.send(client.get(&url)) => result,
+      result = gate.send(client.get(&url)) => result,
+      result = gate.send(client.get(&url)) => result,
+      result = gate.send(client.get(&url)) => result,
+    }
+    .unwrap();
     assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
     assert!(start.elapsed() >= Duration::from_millis(70));
     limited.assert_async().await;
@@ -195,13 +252,16 @@ mod tests {
       .expect(1)
       .create_async()
       .await;
-    let client = reqwest::Client::new();
-    let response = send(
-      client.get(format!("{}/mod", server.url())),
-      "https://cdn.thunderstore.io/mod.zip",
-    )
-    .await
-    .unwrap();
+    let client = client_builder()
+      .no_proxy()
+      .resolve("cdn.thunderstore.io", server.socket_address())
+      .build()
+      .unwrap();
+    let url = format!(
+      "http://cdn.thunderstore.io:{}/mod",
+      server.socket_address().port()
+    );
+    let response = send(client.get(&url), &url).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     limited.assert_async().await;
     success.assert_async().await;
@@ -220,5 +280,88 @@ mod tests {
     .unwrap();
     assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
     unrelated.assert_async().await;
+  }
+
+  #[tokio::test]
+  async fn paces_redirects_and_drops_cross_origin_credentials() {
+    let mut server = mockito::Server::new_async().await;
+    let port = server.socket_address().port();
+    let cdn_url = format!("http://cdn.thunderstore.io:{port}/redirect");
+    let origin = server
+      .mock("GET", "/origin")
+      .with_status(302)
+      .with_header("Location", &cdn_url)
+      .expect(1)
+      .create_async()
+      .await;
+    let redirect = server
+      .mock("GET", "/redirect")
+      .with_status(307)
+      .match_header("authorization", mockito::Matcher::Missing)
+      .match_header("cookie", mockito::Matcher::Missing)
+      .with_header("Location", "/final")
+      .expect(1)
+      .create_async()
+      .await;
+    let limited = server
+      .mock("GET", "/final")
+      .with_status(429)
+      .with_header("Retry-After", "0")
+      .expect(1)
+      .create_async()
+      .await;
+    let success = server
+      .mock("GET", "/final")
+      .with_status(200)
+      .match_header("authorization", mockito::Matcher::Missing)
+      .match_header("Range", "bytes=0-3")
+      .with_body("data")
+      .expect(1)
+      .create_async()
+      .await;
+    let client = client_builder()
+      .no_proxy()
+      .resolve("thunderstore.io", server.socket_address())
+      .resolve("cdn.thunderstore.io", server.socket_address())
+      .build()
+      .unwrap();
+    let url = format!("http://thunderstore.io:{port}/origin");
+    let start = Instant::now();
+    let response = send(
+      client
+        .get(&url)
+        .basic_auth("test", Some("test"))
+        .header("Cookie", "session=test")
+        .header("Range", "bytes=0-3"),
+      &url,
+    )
+    .await
+    .unwrap();
+    assert_eq!(response.url().path(), "/final");
+    assert_eq!(response.text().await.unwrap(), "data");
+    assert!(start.elapsed() >= Duration::from_secs(3));
+    origin.assert_async().await;
+    redirect.assert_async().await;
+    limited.assert_async().await;
+    success.assert_async().await;
+  }
+
+  #[tokio::test]
+  async fn stops_redirect_loops() {
+    let mut server = mockito::Server::new_async().await;
+    let redirect = server
+      .mock("GET", "/loop")
+      .with_status(302)
+      .with_header("Location", "/loop")
+      .expect(11)
+      .create_async()
+      .await;
+    let url = format!("{}/loop", server.url());
+    let result = send(client_builder().build().unwrap().get(&url), &url).await;
+    assert!(result
+      .unwrap_err()
+      .to_string()
+      .contains("Too many mod download redirects"));
+    redirect.assert_async().await;
   }
 }

--- a/src/odin/utils/thunderstore_http.rs
+++ b/src/odin/utils/thunderstore_http.rs
@@ -1,0 +1,224 @@
+use super::thunderstore_auth::with_thunderstore_auth;
+use crate::errors::ValheimModError;
+use reqwest::{RequestBuilder, Response, StatusCode};
+use std::time::{Duration, SystemTime};
+use tokio::sync::Mutex;
+use tokio::time::{sleep_until, Instant};
+
+const MAX_RETRIES: u32 = 3;
+static THUNDERSTORE: RequestGate =
+  RequestGate::new(Duration::from_secs(1), Duration::from_secs(60));
+
+struct RequestGate {
+  next_request: Mutex<Option<Instant>>,
+  spacing: Duration,
+  retry_delay: Duration,
+}
+
+impl RequestGate {
+  const fn new(spacing: Duration, retry_delay: Duration) -> Self {
+    Self {
+      next_request: Mutex::const_new(None),
+      spacing,
+      retry_delay,
+    }
+  }
+
+  // Hold the gate through response headers so another worker cannot miss a new cooldown.
+  async fn send(&self, request: RequestBuilder) -> Result<Response, ValheimModError> {
+    for attempt in 0..=MAX_RETRIES {
+      let mut next = self.next_request.lock().await;
+      if let Some(deadline) = *next {
+        sleep_until(deadline).await;
+      }
+      *next = Some(Instant::now() + self.spacing);
+      let pending = request
+        .try_clone()
+        .ok_or_else(|| ValheimModError::DownloadError("Cannot retry mod request".into()))?
+        .send();
+      // Bound the wait for headers without limiting how long a download body can take.
+      let response = tokio::time::timeout(Duration::from_secs(60), pending)
+        .await
+        .map_err(|_| {
+          ValheimModError::DownloadError(
+            "Timed out waiting for Thunderstore response headers".into(),
+          )
+        })?
+        .map_err(|e| ValheimModError::DownloadError(e.to_string()))?;
+      if response.status() != StatusCode::TOO_MANY_REQUESTS {
+        return Ok(response);
+      }
+
+      let delay = response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| retry_after(value, SystemTime::now()))
+        .unwrap_or(self.retry_delay * 2u32.pow(attempt))
+        .max(self.spacing);
+      let Some(deadline) = Instant::now().checked_add(delay) else {
+        return Err(ValheimModError::DownloadError(
+          "Thunderstore retry time is too far in the future".into(),
+        ));
+      };
+      *next = Some(deadline);
+      if attempt == MAX_RETRIES {
+        return Ok(response);
+      }
+      log::warn!(
+        "Thunderstore rate limit reached; waiting {} seconds before retrying ({}/{})",
+        delay.as_secs(),
+        attempt + 1,
+        MAX_RETRIES
+      );
+      // Release the lock before retrying; all queued workers share the deadline.
+    }
+    unreachable!("the final attempt returns its response")
+  }
+}
+
+fn retry_after(value: &str, now: SystemTime) -> Option<Duration> {
+  let value = value.trim();
+  if let Ok(seconds) = value.parse::<u64>() {
+    return Some(Duration::from_secs(seconds));
+  }
+  let date = chrono::DateTime::parse_from_rfc2822(value).ok()?;
+  let deadline: SystemTime = date.into();
+  Some(deadline.duration_since(now).unwrap_or_default())
+}
+
+/// Pace Thunderstore lookups and downloads together, including retries after a 429.
+/// Other hosts keep their existing request behavior.
+pub(crate) async fn send(request: RequestBuilder, url: &str) -> Result<Response, ValheimModError> {
+  let is_thunderstore = reqwest::Url::parse(url).ok().is_some_and(|url| {
+    url
+      .host_str()
+      .is_some_and(|host| host == "thunderstore.io" || host.ends_with(".thunderstore.io"))
+  });
+  if is_thunderstore {
+    THUNDERSTORE
+      .send(with_thunderstore_auth(request, url))
+      .await
+  } else {
+    request
+      .send()
+      .await
+      .map_err(|e| ValheimModError::DownloadError(e.to_string()))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn reads_seconds_and_http_dates() {
+    let now: SystemTime = chrono::DateTime::parse_from_rfc2822("Wed, 02 Sep 2015 07:28:00 GMT")
+      .unwrap()
+      .into();
+    assert_eq!(retry_after("120", now), Some(Duration::from_secs(120)));
+    assert_eq!(
+      retry_after("Wed, 02 Sep 2015 07:30:00 GMT", now),
+      Some(Duration::from_secs(120))
+    );
+    assert_eq!(
+      retry_after("Wed, 02 Sep 2015 07:00:00 GMT", now),
+      Some(Duration::ZERO)
+    );
+    assert_eq!(retry_after("invalid", now), None);
+  }
+
+  #[tokio::test]
+  async fn retries_after_shared_cooldown() {
+    let mut server = mockito::Server::new_async().await;
+    let limited = server
+      .mock("GET", "/mod")
+      .with_status(429)
+      .with_header("Retry-After", "1")
+      .expect(1)
+      .create_async()
+      .await;
+    let success = server
+      .mock("GET", "/mod")
+      .with_status(200)
+      .expect(2)
+      .create_async()
+      .await;
+    let gate = RequestGate::new(Duration::from_millis(30), Duration::from_millis(10));
+    let client = reqwest::Client::new();
+    let start = Instant::now();
+    let (first, second) = tokio::join!(
+      gate.send(client.get(format!("{}/mod", server.url()))),
+      gate.send(client.get(format!("{}/mod", server.url()))),
+    );
+    assert_eq!(first.unwrap().status(), StatusCode::OK);
+    assert_eq!(second.unwrap().status(), StatusCode::OK);
+    assert!(start.elapsed() >= Duration::from_millis(1030));
+    limited.assert_async().await;
+    success.assert_async().await;
+  }
+
+  #[tokio::test]
+  async fn stops_after_bounded_retries_with_backoff() {
+    let mut server = mockito::Server::new_async().await;
+    let limited = server
+      .mock("GET", "/mod")
+      .with_status(429)
+      .with_header("Retry-After", "invalid")
+      .expect(4)
+      .create_async()
+      .await;
+    let gate = RequestGate::new(Duration::ZERO, Duration::from_millis(10));
+    let start = Instant::now();
+    let response = gate
+      .send(reqwest::Client::new().get(format!("{}/mod", server.url())))
+      .await
+      .unwrap();
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert!(start.elapsed() >= Duration::from_millis(70));
+    limited.assert_async().await;
+  }
+
+  #[tokio::test]
+  async fn cdn_requests_retry_but_other_hosts_do_not() {
+    let mut server = mockito::Server::new_async().await;
+    let limited = server
+      .mock("GET", "/mod")
+      .with_status(429)
+      .with_header("Retry-After", "0")
+      .expect(1)
+      .create_async()
+      .await;
+    let success = server
+      .mock("GET", "/mod")
+      .with_status(200)
+      .expect(1)
+      .create_async()
+      .await;
+    let client = reqwest::Client::new();
+    let response = send(
+      client.get(format!("{}/mod", server.url())),
+      "https://cdn.thunderstore.io/mod.zip",
+    )
+    .await
+    .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    limited.assert_async().await;
+    success.assert_async().await;
+
+    let unrelated = server
+      .mock("GET", "/other")
+      .with_status(429)
+      .expect(1)
+      .create_async()
+      .await;
+    let response = send(
+      client.get(format!("{}/other", server.url())),
+      "https://thunderstore.io.example.com/mod.zip",
+    )
+    .await
+    .unwrap();
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    unrelated.assert_async().await;
+  }
+}


### PR DESCRIPTION
Thunderstore can return `429 Too Many Requests` during mod setup and stop server startup. Version checks currently retry immediately and can send more requests through fallback URLs.

This change spaces Thunderstore requests one second apart, including redirects and CDN downloads. Workers share a cooldown and wait while a blocked request retries. Odin respects `Retry-After`, or waits 60, 120, then 240 seconds when no valid retry time is supplied. It also removes the extra HEAD request before downloads and bumps Odin to 2.1.1.

Related discussion: https://github.com/mbround18/valheim-docker/discussions/1482

## Validation

- Full workspace tests passed with `RUST_TEST_THREADS=1`. Parallel execution exposed an existing environment-variable race in a BepInEx test.
- Formatting and `cargo clippy --all -- -D warnings` passed.
- Built Odin in Docker and ran it in an isolated Ubuntu 24.04 container. Four wildcard mods installed after simulated 429s during version checks, downloads, and CDN redirects. All fifteen requests were at least one second apart.
- With four workers receiving persistent 429s, Odin stopped after four requests without trying alternate endpoints.
- Five local Codex reviews completed, findings addressed, and the final GitHub Codex review passed on this commit in the fork.

## Checklist

- [ ] Appropriate labels added by a maintainer.
- [x] Tested locally.
- [ ] Maintainer reviewer assigned.
- [x] Validated Odin in Docker on Ubuntu 24.04.
