### PR TITLE
Run steam as uid 1000 so the documented rootless user directive works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ USER root
 
 ENV TZ=America/Los_Angeles \
     DEBIAN_FRONTEND=noninteractive \
-    PUID=111 \
+    PUID=1000 \
     PGID=1000
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/src/scripts/build/setup-system.sh
+++ b/src/scripts/build/setup-system.sh
@@ -36,6 +36,14 @@ else
   fi
 fi
 
+# The base image ships an `ubuntu` account on uid 1000. Retire whichever account holds
+# the target uid so `steam` (the documented `user: 1000:1000`) can own it.
+EXISTING_UID_USER="$(getent passwd "${PUID}" | cut -d: -f1 || true)"
+if [ -n "${EXISTING_UID_USER}" ] && [ "${EXISTING_UID_USER}" != "steam" ]; then
+  echo "uid ${PUID} is held by '${EXISTING_UID_USER}'; removing it in favour of 'steam'"
+  userdel -r "${EXISTING_UID_USER}" 2>/dev/null || userdel "${EXISTING_UID_USER}"
+fi
+
 # Create/update steam user
 if id -u steam >/dev/null 2>&1; then
   usermod -u "${PUID}" -g "${PGID}" -d /home/steam -s /bin/bash steam || true
@@ -48,3 +56,5 @@ mkdir -p /home/steam/.steam/steam/package
 mkdir -p /home/steam /home/steam/valheim /home/steam/.steam
 mkdir -p /tmp/dumps && chmod ugo+rw /tmp/dumps
 chown -R "${PUID}:${PGID}" /home/steam
+# Group-writable home so a runtime uid that only shares the gid (arbitrary-uid orchestrators) still works.
+chmod -R g+rwX /home/steam


### PR DESCRIPTION
# Description

The rootless docs (README "Security: Migration to Rootless Design", `docs/tutorials/rootless_design.md`) tell users to run the image as `user: "1000:1000"` / `runAsUser: 1000`. The image itself creates `steam` as uid **111** (`Dockerfile`: `PUID=111`) with a `750` home directory, and uid 1000 is the base image's `ubuntu` account. So the documented configuration cannot write `$HOME`, `~/.steam` or `/home/steam/backups`, and startup fails:

```
mkdir: cannot create directory ‘/home/steam/backups’: Permission denied
...
ERROR odin::server::install: Preflight write check failed: WRITE FAIL /home/steam/.steam:
```

(#1349 is a symptom of the same mismatch.)

## Contributions

- `Dockerfile`: `PUID` defaults to `1000`, matching the documentation.
- `src/scripts/build/setup-system.sh`: before creating `steam`, retire whichever account already holds the target uid — the base image's `ubuntu` on `ubuntu-24` — so `steam` can own it. Written against `${PUID}` rather than a hard-coded name so a custom `PUID` build behaves the same.
- `src/scripts/build/setup-system.sh`: `chmod -R g+rwX /home/steam` so a runtime uid that only shares gid 1000 (arbitrary-uid orchestrators) still has a writable home.

No change for users who start the container without a `user` directive: the entrypoint's `PUID:PGID` chown path is untouched, it just targets 1000 now.

## Checklist

- [ ] I added one or multiple labels which best describes this PR. (`patch` / `bug` — I can't set labels as an external contributor)
- [x] I have tested the changes locally.
- [ ] This PR has a reviewer on it.
- [x] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)

Validation (built with `docker build --target valheim`):

```
$ docker run --rm --user 1000:1000 --security-opt no-new-privileges --entrypoint sh <image> -c 'id; getent passwd 1000; touch /home/steam/.steam/probe && echo HOME-writable'
uid=1000(steam) gid=1000(steam) groups=1000(steam)
steam:x:1000:1000::/home/steam:/bin/bash
HOME-writable
```

and a full start as `1000:1000` gets past the preflight and through the SteamCMD install (2.1 GB) to `Opened Steam server`. Running in production on a k3s cluster with `runAsUser: 1000`, `readOnlyRootFilesystem: true`, all capabilities dropped.