### PR TITLE
Sync SteamCMD app info and retry when +app_update fails

### DIFF
--- a/src/odin/server/install.rs
+++ b/src/odin/server/install.rs
@@ -12,7 +12,11 @@ use std::{
 use crate::utils::common_paths;
 use crate::utils::fs::remove_path_cautious;
 use crate::utils::steamcmd_args::{compose_app_update_arg, BetaConfig};
-use crate::{constants, steamcmd::run_with_retries, utils::get_working_dir};
+use crate::{
+  constants,
+  steamcmd::{output_with_retries, run_with_retries},
+  utils::get_working_dir,
+};
 use crate::{executable::parse_command_args, utils::environment};
 use walkdir::WalkDir;
 
@@ -43,6 +47,28 @@ pub fn add_beta_args(
     args.push(String::from("validate"));
   } else {
     debug!("Skipping SteamCMD validate: VALIDATE_ON_INSTALL=0");
+  }
+}
+
+/// `+app_update` can race SteamCMD's own app-info sync (`Missing configuration`).
+pub(crate) fn app_info_sync_args(app_id: i64) -> Vec<String> {
+  vec![
+    String::from("+@ShutdownOnFailedCommand 1"),
+    String::from("+login anonymous"),
+    String::from("+app_info_update 1"),
+    format!("+app_info_print {app_id}"),
+    String::from("+quit"),
+  ]
+}
+
+fn sync_app_info(app_id: i64) {
+  match output_with_retries(&app_info_sync_args(app_id)) {
+    Ok(output) if output.status.success() => {}
+    Ok(output) => warn!(
+      "SteamCMD app info sync exited with {:?}",
+      output.status.code()
+    ),
+    Err(e) => warn!("SteamCMD app info sync could not run ({e})"),
   }
 }
 
@@ -157,6 +183,11 @@ pub fn install(app_id: i64) -> io::Result<ExitStatus> {
   args = parse_command_args(args);
 
   let mut result = run_with_retries(&args);
+
+  if !matches!(&result, Ok(status) if status.success()) {
+    sync_app_info(app_id);
+    result = run_with_retries(&args);
+  }
 
   // A failed app_update can leave SteamCMD's download bookkeeping stale, which
   // it then reports as `state is 0x6 after update job` on every subsequent run.
@@ -982,6 +1013,20 @@ mod tests {
     let mut args = vec![];
     add_beta_args(&mut args, use_public_beta, beta_branch, beta_password);
     assert_eq!(args, expected);
+  }
+
+  #[test]
+  fn test_app_info_sync_args_force_sync_then_wait_for_the_app() {
+    assert_eq!(
+      app_info_sync_args(896660),
+      vec![
+        "+@ShutdownOnFailedCommand 1",
+        "+login anonymous",
+        "+app_info_update 1",
+        "+app_info_print 896660",
+        "+quit"
+      ]
+    );
   }
 
   #[test]


### PR DESCRIPTION
# Description

On some links SteamCMD issues `+app_update` while its own app-info sync for the app is still in flight, and the install fails every time with:

```
ERROR! Failed to install app '896660' (Missing configuration)
WARN odin::steamcmd: steamcmd failed on attempt 2/3 with exit code Some(8); retrying in 10s
...
WARN odin::server::install: SteamCMD could not complete the app update (exit code 8). Resetting download state
ERROR odin::server::install: steamcmd exited with code: 8
```

`STEAMCMD_RETRY_ATTEMPTS` and the download-state reset can't help: each attempt starts the same race. We hit this deterministically from an OVH Public Cloud instance (3/3 attempts, every container start); the same image installs fine from a residential connection. The known SteamCMD workaround is to force the app-info sync first (`+app_info_update 1`) and wait for the app's entry (`+app_info_print <id>`).

## Contributions

- `install()`: if the normal `run_with_retries` result is not a success, run one SteamCMD session with captured output (`+login anonymous +app_info_update 1 +app_info_print <app_id>`) so the app's info is cached, then run the retries once more. Placed before the existing download-state recovery, which is unchanged.
- The sync is best effort: a failed sync is logged with `warn!` and the retry proceeds as before.
- Output is captured (`output_with_retries`) so the app's metadata dump does not land in the container log.
- Links that never hit the race pay nothing.
- One unit test on the sync command list.

## Checklist

- [ ] I added one or multiple labels which best describes this PR. (`patch` / `bug` — I can't set labels as an external contributor)
- [x] I have tested the changes locally.
- [ ] This PR has a reviewer on it.
- [x] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)

Validation: `cargo test` (246 passed), `cargo fmt --check`, `cargo clippy -- -D warnings` clean. Built with `docker build --target valheim` and running on the OVH instance where the race was 3/3 reproducible: with the sync in front of `+app_update` the 2.1 GB install completed and the server started; the failure-driven form here runs the sync only after the first round of attempts fails.