### PR TITLE
Track who is online: fix Odin's player list and expose names in Huginn

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -344,7 +344,7 @@ This repo includes a CLI tool called [Odin] for managing the server inside the c
 | CONNECT_REMOTE_HOST        | `<unset>`            | FALSE    | Optional host/IP override for `/connect/remote`. If unset, Huginn falls back to `PUBLIC_ADDRESS`, then `ADDRESS`, then Odin public IP resolution.                                  |
 | CONNECT_STEAM_APP_ID       | `892970`             | FALSE    | Steam app id used for connect deeplink generation (`steam://run/<APP_ID>//+connect%20HOST:PORT`).                                                                                  |
 
-- `/metrics` provides a Prometheus-style metrics output.
+- `/metrics` provides Prometheus metrics, listed in [metrics.md](./metrics.md).
 - `/status` provides a more traditional status page.
 - `/connect/local` redirects to `steam://run/892970//+connect%20127.0.0.1:PORT` (or returns JSON for browser CORS fetch clients).
 - `/connect/remote` redirects to `steam://run/892970//+connect%20<public host>:PORT` (or returns JSON for browser CORS fetch clients).
@@ -366,6 +366,10 @@ This repo includes a CLI tool called [Odin] for managing the server inside the c
 ### [BepInEx Support](./bepinex.md)
 
 As of [March 2021](./bepinex.md), the TYPE variable can be used to automatically install BepInEx. For details, see [Getting started with mods](./tutorials/getting_started_with_mods.md).
+
+### [Metrics](./metrics.md)
+
+Huginn exposes Prometheus metrics for the server, the players online and the host: [metrics reference](./metrics.md).
 
 ### [Webhook Support](./webhooks.md)
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,61 @@
+# Metrics
+
+Huginn serves Prometheus metrics at `http://<host>:<HTTP_PORT>/metrics` (default port `3000`). All metrics are gauges. Server metrics come from the Steam A2S query, player metrics from Odin's player tracking (see [players](#players)), system metrics from the container's view of the host.
+
+## Server
+
+Labels on every server metric: `name` (server name), `version` (Steam server version tag), `map` (world name).
+
+| Metric                         | Labels                 | Description                                                         |
+| ------------------------------ | ---------------------- | ------------------------------------------------------------------- |
+| `valheim_online`               | `name`,`version`,`map` | `1` when the server answers the Steam query, `0` when it does not. |
+| `valheim_current_player_count` | `name`,`version`,`map` | Players connected.                                                  |
+| `valheim_max_player_count`     | `name`,`version`,`map` | Player slots.                                                       |
+| `valheim_bepinex_installed`    | `name`,`version`,`map` | `1` when BepInEx is installed, else `0`.                            |
+
+## Players
+
+One series per player currently online. Names come from the server log (`Got character ZDOID from <name>`), which Odin tracks in `player.list`; Valheim does not publish names over the Steam query. Series disappear when the player leaves.
+
+| Metric                                    | Labels   | Description                                                   |
+| ----------------------------------------- | -------- | ------------------------------------------------------------- |
+| `valheim_player_online`                   | `player` | Always `1` while the character is online.                     |
+| `valheim_player_joined_timestamp_seconds` | `player` | Unix time the player joined. Kept across deaths and respawns. |
+
+Time in game: `time() - valheim_player_joined_timestamp_seconds`.
+
+## System
+
+| Metric                             | Labels   | Description                                    |
+| ---------------------------------- | -------- | ---------------------------------------------- |
+| `valheim_sys_memory_total_bytes`   |          | Total memory.                                  |
+| `valheim_sys_memory_used_bytes`    |          | Memory in use.                                 |
+| `valheim_sys_swap_total_bytes`     |          | Total swap.                                    |
+| `valheim_sys_swap_used_bytes`      |          | Swap in use.                                   |
+| `valheim_sys_disk_total_bytes`     |          | Total size of all mounted disks.               |
+| `valheim_sys_disk_available_bytes` |          | Free space across all mounted disks.           |
+| `valheim_sys_cpu_logical_count`    |          | Logical CPUs.                                  |
+| `valheim_sys_load_average`         | `window` | Load average; `window` is `1m`, `5m` or `15m`. |
+
+## Example
+
+```
+valheim_online{name="My Server", version="g=1.0.7,n=39", map="Dedicated"} 1
+valheim_current_player_count{name="My Server", version="g=1.0.7,n=39", map="Dedicated"} 2
+valheim_max_player_count{name="My Server", version="g=1.0.7,n=39", map="Dedicated"} 10
+valheim_bepinex_installed{name="My Server", version="g=1.0.7,n=39", map="Dedicated"} 0
+valheim_sys_memory_total_bytes 8317225140
+valheim_sys_memory_used_bytes 6340026040
+valheim_sys_swap_total_bytes 0
+valheim_sys_swap_used_bytes 0
+valheim_sys_disk_total_bytes 833209548800
+valheim_sys_disk_available_bytes 450985697280
+valheim_sys_cpu_logical_count 4
+valheim_sys_load_average {window="1m"} 0.98
+valheim_sys_load_average {window="5m"} 0.94
+valheim_sys_load_average {window="15m"} 1.01
+valheim_player_online{player="Viking"} 1
+valheim_player_joined_timestamp_seconds{player="Viking"} 1789020710
+```
+
+Scrape it like any other target (Prometheus `static_configs`, or a Kubernetes `ServiceMonitor` on the Huginn port). A Grafana dashboard walkthrough is in [discussion #330](https://github.com/mbround18/valheim-docker/discussions/330).

--- a/src/huginn/README.md
+++ b/src/huginn/README.md
@@ -84,7 +84,7 @@ huginn &
 
 | Endpoint          | Description                                                                                                                                                                       |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/metrics`        | Provides Prometheus-compatible server status output. [Guide to setting up a dashboard](https://github.com/mbround18/valheim-docker/discussions/330).                              |
+| `/metrics`        | Provides Prometheus-compatible server status output, including `valheim_player_online{player="<name>"} 1` and `valheim_player_joined_timestamp_seconds{player="<name>"}` per player online. [Guide to setting up a dashboard](https://github.com/mbround18/valheim-docker/discussions/330). |
 | `/status`         | Provides a more traditional JSON output of the server status.                                                                                                                     |
 | `/connect/local`  | Redirect to `steam://run/<CONNECT_STEAM_APP_ID>//+connect%20127.0.0.1:PORT`. Browser CORS fetch clients receive JSON `{ steam_url, host, port, redirect }` for compatibility.     |
 | `/connect/remote` | Redirect to `steam://run/<CONNECT_STEAM_APP_ID>//+connect%20<public host>:PORT`. Browser CORS fetch clients receive JSON `{ steam_url, host, port, redirect }` for compatibility. |
@@ -92,7 +92,7 @@ huginn &
 | `/readiness`      | Kubernetes readiness probe; `200` only if the server is online.                                                                                                                   |
 | `/liveness`       | Kubernetes liveness probe; returns `200` when Huginn is alive.                                                                                                                    |
 | `/mods`           | Returns installed mod metadata.                                                                                                                                                   |
-| `/players`        | Returns player counts and player names when available.                                                                                                                            |
+| `/players`        | Returns player counts plus `names` and `sessions` (`name`, `joined_at` unix time) of the players online, from the server log via Odin (Valheim's Steam query carries no names).                                                |
 | `/metadata`       | Returns safe Odin/Huginn runtime metadata (ports, build id, beta mode, scheduler toggles/schedules, cache/runtime info).                                                          |
 | `/openapi.json`   | OpenAPI specification for the HTTP API.                                                                                                                                           |
 | `/docs`           | Swagger UI for interactive API documentation.                                                                                                                                     |

--- a/src/huginn/README.md
+++ b/src/huginn/README.md
@@ -84,7 +84,7 @@ huginn &
 
 | Endpoint          | Description                                                                                                                                                                       |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/metrics`        | Provides Prometheus-compatible server status output, including `valheim_player_online{player="<name>"} 1` and `valheim_player_joined_timestamp_seconds{player="<name>"}` per player online. [Guide to setting up a dashboard](https://github.com/mbround18/valheim-docker/discussions/330). |
+| `/metrics`        | Prometheus metrics for the server, players online and host; full list in [docs/metrics.md](../../docs/metrics.md). [Guide to setting up a dashboard](https://github.com/mbround18/valheim-docker/discussions/330).                                        |
 | `/status`         | Provides a more traditional JSON output of the server status.                                                                                                                     |
 | `/connect/local`  | Redirect to `steam://run/<CONNECT_STEAM_APP_ID>//+connect%20127.0.0.1:PORT`. Browser CORS fetch clients receive JSON `{ steam_url, host, port, redirect }` for compatibility.     |
 | `/connect/remote` | Redirect to `steam://run/<CONNECT_STEAM_APP_ID>//+connect%20<public host>:PORT`. Browser CORS fetch clients receive JSON `{ steam_url, host, port, redirect }` for compatibility. |

--- a/src/huginn/routes/metrics.rs
+++ b/src/huginn/routes/metrics.rs
@@ -1,4 +1,5 @@
 use crate::fetch_info;
+use odin::log_filters::PlayerList;
 use shared::system::collect_system_metrics;
 
 fn escape_prom_label_value(value: &str) -> String {
@@ -17,6 +18,16 @@ pub fn invoke() -> String {
     version = escape_prom_label_value(&info.version),
     map = escape_prom_label_value(&info.map)
   );
+  let players = PlayerList::online().into_iter().flat_map(|p| {
+    let player = escape_prom_label_value(&p.name);
+    [
+      format!("valheim_player_online{{player=\"{player}\"}} 1"),
+      format!(
+        "valheim_player_joined_timestamp_seconds{{player=\"{player}\"}} {}",
+        p.joined_at
+      ),
+    ]
+  });
   let content = [
     format!(
       "valheim_online{labels} {online}",
@@ -65,5 +76,12 @@ pub fn invoke() -> String {
       sys.load_average_fifteen
     ),
   ];
-  format!("{}\n", content.join("\n"))
+  format!(
+    "{}\n",
+    content
+      .into_iter()
+      .chain(players)
+      .collect::<Vec<_>>()
+      .join("\n")
+  )
 }

--- a/src/huginn/routes/openapi.rs
+++ b/src/huginn/routes/openapi.rs
@@ -155,7 +155,7 @@ pub fn invoke() -> Json {
         },
         "PlayersResponse": {
           "type": "object",
-          "required": ["online", "players", "max_players", "names"],
+          "required": ["online", "players", "max_players", "names", "sessions"],
           "properties": {
             "online": { "type": "boolean" },
             "players": { "type": "integer", "format": "uint8", "minimum": 0, "maximum": 255 },
@@ -163,6 +163,17 @@ pub fn invoke() -> Json {
             "names": {
               "type": "array",
               "items": { "type": "string" }
+            },
+            "sessions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["name", "joined_at"],
+                "properties": {
+                  "name": { "type": "string" },
+                  "joined_at": { "type": "integer", "format": "int64", "description": "Unix time of the join" }
+                }
+              }
             }
           }
         },

--- a/src/huginn/routes/players.rs
+++ b/src/huginn/routes/players.rs
@@ -1,4 +1,5 @@
 use crate::{fetch_info, query_socket_addr};
+use odin::log_filters::PlayerList;
 use warp::reply::json;
 use warp::reply::Json;
 
@@ -8,21 +9,36 @@ pub struct PlayersResponse {
   pub players: u8,
   pub max_players: u8,
   pub names: Vec<String>,
+  pub sessions: Vec<Session>,
+}
+
+#[derive(serde::Serialize)]
+pub struct Session {
+  pub name: String,
+  pub joined_at: i64,
 }
 
 pub fn invoke() -> Json {
   // Reuse cached status information from huginn's fetch path.
   let info = fetch_info();
 
-  // Attempt to query player names directly via A2S; degrade gracefully on error.
-  let mut names: Vec<String> = Vec::new();
-  if info.online {
+  // Valheim does not publish names over A2S; Odin tracks them from the server log.
+  let sessions: Vec<Session> = PlayerList::online()
+    .into_iter()
+    .map(|p| Session {
+      name: p.name,
+      joined_at: p.joined_at,
+    })
+    .collect();
+  let mut names: Vec<String> = sessions.iter().map(|s| s.name.clone()).collect();
+  if names.is_empty() && info.online {
     let Some(socket) = query_socket_addr() else {
       return json(&PlayersResponse {
         online: info.online,
         players: info.players,
         max_players: info.max_players,
         names,
+        sessions,
       });
     };
     if let Ok(client) = a2s::A2SClient::new() {
@@ -46,5 +62,6 @@ pub fn invoke() -> Json {
     players: info.players,
     max_players: info.max_players,
     names,
+    sessions,
   })
 }

--- a/src/odin/commands/logs.rs
+++ b/src/odin/commands/logs.rs
@@ -71,9 +71,7 @@ fn handle_line_core(path: &PathBuf, line: &str) {
     return;
   }
 
-  if is_env_var_truthy("PLAYER_EVENT_NOTIFICATIONS") {
-    handle_player_events(line);
-  }
+  handle_player_events(line);
 
   let file_name = match path.file_name().and_then(|name| name.to_str()) {
     Some(name) => name,

--- a/src/odin/commands/start.rs
+++ b/src/odin/commands/start.rs
@@ -1,5 +1,6 @@
 use crate::{
   files::config::load_config,
+  log_filters::PlayerList,
   notifications::enums::{event_status::EventStatus, notification_event::NotificationEvent},
   server,
 };
@@ -10,6 +11,7 @@ use std::process::exit;
 pub fn invoke(dry_run: bool) {
   info!(target: "commands_start", "Setting up start scripts...");
   NotificationEvent::Start(EventStatus::Running).send_notification(None);
+  PlayerList::clear();
   debug!(target: "commands_start", "Loading config file...");
   let config = load_config();
   debug!(target: "commands_start", "Dry run condition: {dry_run}");

--- a/src/odin/lib.rs
+++ b/src/odin/lib.rs
@@ -11,7 +11,7 @@ pub mod steamcmd;
 pub mod traits;
 pub mod utils;
 
-mod log_filters;
+pub mod log_filters;
 
 // Re-export commonly used types for convenience
 pub use mods::installed_mods::installed_mods_with_paths;

--- a/src/odin/log_filters/mod.rs
+++ b/src/odin/log_filters/mod.rs
@@ -1,5 +1,5 @@
 mod player;
 mod probes;
 
-pub use player::{handle_player_events, PlayerList};
+pub use player::{handle_player_events, OnlinePlayer, PlayerList};
 pub use probes::handle_launch_probes;

--- a/src/odin/log_filters/mod.rs
+++ b/src/odin/log_filters/mod.rs
@@ -1,5 +1,5 @@
 mod player;
 mod probes;
 
-pub use player::handle_player_events;
+pub use player::{handle_player_events, PlayerList};
 pub use probes::handle_launch_probes;

--- a/src/odin/log_filters/player.rs
+++ b/src/odin/log_filters/player.rs
@@ -14,6 +14,8 @@ struct Player {
   zdo_index: u16,
   name: String,
   last_seen: i64,
+  #[serde(default)]
+  joined_at: i64,
 }
 
 impl Clone for Player {
@@ -23,8 +25,16 @@ impl Clone for Player {
       zdo_index: self.zdo_index,
       name: String::from(&self.name),
       last_seen: self.last_seen,
+      joined_at: self.joined_at,
     }
   }
+}
+
+/// A player currently online, as exposed to Huginn.
+pub struct OnlinePlayer {
+  pub name: String,
+  /// Unix timestamp of the join (kept across respawns).
+  pub joined_at: i64,
 }
 
 impl Default for Player {
@@ -37,6 +47,7 @@ impl Default for Player {
       zdo_index: 0,
       name: "Unknown".to_string(),
       last_seen: epoch,
+      joined_at: epoch,
     }
   }
 }
@@ -53,13 +64,21 @@ impl PlayerList {
 
   /// Records `id` as online under `name`; returns true if the player was not online before.
   fn join(&mut self, id: u64, zdo_index: u16, name: String) -> bool {
-    let is_new = !self.players.iter().any(|p| p.id == id);
+    let now = Utc::now().timestamp();
+    let existing = self
+      .players
+      .iter()
+      .find(|p| p.id == id)
+      .map(|p| p.joined_at);
+    let is_new = existing.is_none();
+    let joined_at = existing.unwrap_or(now);
     self.players.retain(|p| p.id != id);
     self.players.push(Player {
       id,
       zdo_index,
       name,
-      last_seen: Utc::now().timestamp(),
+      last_seen: now,
+      joined_at,
     });
     is_new
   }
@@ -97,12 +116,15 @@ impl PlayerList {
     PlayerList { players: vec![] }.save();
   }
 
-  /// Names of the players currently online.
-  pub fn online_names() -> Vec<String> {
+  /// The players currently online.
+  pub fn online() -> Vec<OnlinePlayer> {
     PlayerList::default()
       .players
       .into_iter()
-      .map(|p| p.name)
+      .map(|p| OnlinePlayer {
+        name: p.name,
+        joined_at: p.joined_at,
+      })
       .collect()
   }
 }
@@ -250,10 +272,12 @@ mod tests {
   fn test_join_and_leave() {
     let mut list = PlayerList { players: vec![] };
     assert!(list.join(1, 1, "Player1".to_string()));
+    let joined_at = list.players[0].joined_at;
     // respawn after death: same player, new zdo index, still one entry, no new join
     assert!(!list.join(1, 68, "Player1".to_string()));
     assert_eq!(list.players.len(), 1);
     assert_eq!(list.players[0].zdo_index, 68);
+    assert_eq!(list.players[0].joined_at, joined_at);
 
     assert!(list.leave(2).is_none());
     assert_eq!(list.leave(1).map(|p| p.name).as_deref(), Some("Player1"));
@@ -275,6 +299,7 @@ mod tests {
       zdo_index: 0,
       name: "Player1".to_string(),
       last_seen: Utc::now().timestamp(),
+      joined_at: Utc::now().timestamp(),
     };
 
     let player_list = PlayerList {

--- a/src/odin/log_filters/player.rs
+++ b/src/odin/log_filters/player.rs
@@ -10,7 +10,7 @@ use std::fmt::Display;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct Player {
-  id: u64,
+  id: i64,
   zdo_index: u16,
   name: String,
   last_seen: i64,
@@ -63,7 +63,7 @@ impl PlayerList {
   }
 
   /// Records `id` as online under `name`; returns true if the player was not online before.
-  fn join(&mut self, id: u64, zdo_index: u16, name: String) -> bool {
+  fn join(&mut self, id: i64, zdo_index: u16, name: String) -> bool {
     let now = Utc::now().timestamp();
     let existing = self
       .players
@@ -83,12 +83,12 @@ impl PlayerList {
     is_new
   }
 
-  fn leave(&mut self, id: u64) -> Option<Player> {
+  fn leave(&mut self, id: i64) -> Option<Player> {
     let index = self.players.iter().position(|p| p.id == id)?;
     Some(self.players.remove(index))
   }
 
-  pub fn joined_event(id: u64, zdo_index: u16, name: String) {
+  pub fn joined_event(id: i64, zdo_index: u16, name: String) {
     let mut list = PlayerList::default();
     if list.join(id, zdo_index, name.clone()) {
       info!("Player '{name}' joined");
@@ -102,7 +102,7 @@ impl PlayerList {
     list.save();
   }
 
-  pub fn left_event(id: u64) {
+  pub fn left_event(id: i64) {
     let mut list = PlayerList::default();
     let Some(player) = list.leave(id) else {
       debug!("No player with ID '{id}' found.");
@@ -191,12 +191,12 @@ impl Display for PlayerList {
 pub fn handle_player_events(line: &str) {
   // Regex to capture player joining event with player name, ID and ZDO index
   let joined_regex =
-    Regex::new(r"\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}: Got character ZDOID from (.*) : (\d+:\d+)")
+    Regex::new(r"\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}: Got character ZDOID from (.*) : (-?\d+:\d+)")
       .expect("Failed to compile joined_regex");
 
   // Regex to capture player leaving event with the owning player ID
   let left_regex = Regex::new(
-    r"\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}: Destroying abandoned non persistent zdo \d+:\d+ owner (\d+)"
+    r"\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}: Destroying abandoned non persistent zdo -?\d+:\d+ owner (-?\d+)"
   ).expect("Failed to compile left_regex");
 
   // Handle player joining event
@@ -216,7 +216,7 @@ pub fn handle_player_events(line: &str) {
   // Handle player leaving event
   if let Some(captures) = left_regex.captures(line) {
     debug!("Matched leaving event: '{captures:?}'");
-    match captures[1].parse::<u64>() {
+    match captures[1].parse::<i64>() {
       Ok(id) => PlayerList::left_event(id),
       Err(e) => error!("Failed to process leaving event line '{line}': {e}"),
     }
@@ -224,7 +224,7 @@ pub fn handle_player_events(line: &str) {
 }
 
 /// Extracts the player name, ID, and ZDO index from regex captures for a joining event.
-fn extract_player_details(captures: &regex::Captures) -> Result<(String, u64, u16), String> {
+fn extract_player_details(captures: &regex::Captures) -> Result<(String, i64, u16), String> {
   debug!("Extracting player details from captures: '{captures:?}'");
   let name = captures
     .get(1)
@@ -242,7 +242,7 @@ fn extract_player_details(captures: &regex::Captures) -> Result<(String, u64, u1
 }
 
 /// Extracts the player ID and ZDO index from a string with the format `player_id:zdo_index`.
-fn extract_player_id_and_zdo_index(id_str: Option<&str>) -> Result<(u64, u16), String> {
+fn extract_player_id_and_zdo_index(id_str: Option<&str>) -> Result<(i64, u16), String> {
   debug!("Extracting player ID and ZDO index from string: '{id_str:?}'");
   match id_str {
     Some(id) => {
@@ -251,7 +251,7 @@ fn extract_player_id_and_zdo_index(id_str: Option<&str>) -> Result<(u64, u16), S
         return Err("ID split failed: Invalid format".to_string());
       }
       let player_id = parts[0]
-        .parse::<u64>()
+        .parse::<i64>()
         .map_err(|e| format!("ID parsing failed: {e}"))?;
       let zdo_index = parts[1]
         .parse::<u16>()
@@ -272,6 +272,19 @@ mod tests {
   pub trait NotificationEventTrait {
     #[allow(dead_code)]
     fn send_notification(&self, message: Option<String>);
+  }
+
+  #[test]
+  fn negative_session_ids_parse() {
+    assert_eq!(
+      extract_player_id_and_zdo_index(Some("-1234567890:1")),
+      Ok((-1234567890, 1))
+    );
+    let joined = Regex::new(
+      r"\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}: Got character ZDOID from (.*) : (-?\d+:\d+)",
+    )
+    .unwrap();
+    assert!(joined.is_match("09/10/2026 00:00:00: Got character ZDOID from Viking : -1234567890:1"));
   }
 
   #[test]

--- a/src/odin/log_filters/player.rs
+++ b/src/odin/log_filters/player.rs
@@ -90,9 +90,14 @@ impl PlayerList {
 
   pub fn joined_event(id: u64, zdo_index: u16, name: String) {
     let mut list = PlayerList::default();
-    if list.join(id, zdo_index, name.clone()) && is_env_var_truthy("PLAYER_EVENT_NOTIFICATIONS") {
-      NotificationEvent::Player(Joined)
-        .send_notification(Some(format!("Player {name} has joined the adventure!")));
+    if list.join(id, zdo_index, name.clone()) {
+      info!("Player '{name}' joined");
+      if is_env_var_truthy("PLAYER_EVENT_NOTIFICATIONS") {
+        NotificationEvent::Player(Joined)
+          .send_notification(Some(format!("Player {name} has joined the adventure!")));
+      }
+    } else {
+      info!("Player '{name}' respawned");
     }
     list.save();
   }
@@ -103,8 +108,9 @@ impl PlayerList {
       debug!("No player with ID '{id}' found.");
       return;
     };
+    let name = &player.name;
+    info!("Player '{name}' left");
     if is_env_var_truthy("PLAYER_EVENT_NOTIFICATIONS") {
-      let name = &player.name;
       NotificationEvent::Player(Left)
         .send_notification(Some(format!("Player {name} has left the adventure")));
     }
@@ -200,7 +206,7 @@ pub fn handle_player_events(line: &str) {
       // `0:0` is the character despawning on death, not a join
       Ok((_, 0, _)) => {}
       Ok((name, id, zdo_index)) => {
-        info!("Player '{name}' with ID '{id}' and ZDO index '{zdo_index}' is joining");
+        debug!("Player '{name}' with ID '{id}' and ZDO index '{zdo_index}' is joining");
         PlayerList::joined_event(id, zdo_index, name);
       }
       Err(e) => error!("Failed to process joining event line '{line}': {e}"),

--- a/src/odin/log_filters/player.rs
+++ b/src/odin/log_filters/player.rs
@@ -1,6 +1,7 @@
 use crate::files::FileManager;
 use crate::notifications::enums::notification_event::NotificationEvent;
 use crate::notifications::enums::player::PlayerStatus::{Joined, Left};
+use crate::utils::environment::is_env_var_truthy;
 use chrono::Utc;
 use log::{debug, error, info};
 use regex::Regex;
@@ -50,67 +51,59 @@ impl PlayerList {
     self.write(self.to_string()) // Ensure this writes correctly
   }
 
-  fn get_player_by_id(id: u64) -> Option<Player> {
-    let list = Self::default();
-    list
-      .players
-      .iter()
-      .find(|p| p.id == id)
-      .map(|player| Player {
-        id: player.id,
-        zdo_index: player.zdo_index,
-        name: player.name.clone(),
-        last_seen: player.last_seen,
-      })
-  }
-
-  fn update_or_push(&mut self, player: Player) {
-    if let Some(existing_player) = self
-      .players
-      .iter_mut()
-      .find(|p| p.id == player.id && p.zdo_index == player.zdo_index)
-    {
-      // Update the `last_seen` timestamp if both id and zdo_index match
-      existing_player.last_seen = player.last_seen;
-    } else {
-      // Otherwise, add the new player
-      self.players.push(player);
-    }
-  }
-
-  pub fn joined_event(id: u64, zdo_index: u16, name: String) {
-    let mut list = PlayerList::default(); // Fetch or initialize player list
-    let now = Utc::now();
-    let last_seen = now.timestamp();
-
-    NotificationEvent::Player(Joined)
-      .send_notification(Some(format!("Player {name} has joined the adventure!")));
-
-    // Update or add the player to the list
-    list.update_or_push(Player {
+  /// Records `id` as online under `name`; returns true if the player was not online before.
+  fn join(&mut self, id: u64, zdo_index: u16, name: String) -> bool {
+    let is_new = !self.players.iter().any(|p| p.id == id);
+    self.players.retain(|p| p.id != id);
+    self.players.push(Player {
       id,
       zdo_index,
       name,
-      last_seen,
+      last_seen: Utc::now().timestamp(),
     });
-
-    list.save(); // Save changes to the list
+    is_new
   }
 
-  pub fn left_event(id: u64, zdo_index: u16) {
-    let list = PlayerList::default(); // Fetch or initialize player list
-                                      // Find the player by both ID and ZDO index
-    if let Some(player) = list
-      .players
-      .iter()
-      .find(|player| player.id == id && player.zdo_index == zdo_index)
-    {
+  fn leave(&mut self, id: u64) -> Option<Player> {
+    let index = self.players.iter().position(|p| p.id == id)?;
+    Some(self.players.remove(index))
+  }
+
+  pub fn joined_event(id: u64, zdo_index: u16, name: String) {
+    let mut list = PlayerList::default();
+    if list.join(id, zdo_index, name.clone()) && is_env_var_truthy("PLAYER_EVENT_NOTIFICATIONS") {
+      NotificationEvent::Player(Joined)
+        .send_notification(Some(format!("Player {name} has joined the adventure!")));
+    }
+    list.save();
+  }
+
+  pub fn left_event(id: u64) {
+    let mut list = PlayerList::default();
+    let Some(player) = list.leave(id) else {
+      debug!("No player with ID '{id}' found.");
+      return;
+    };
+    if is_env_var_truthy("PLAYER_EVENT_NOTIFICATIONS") {
       let name = &player.name;
       NotificationEvent::Player(Left)
         .send_notification(Some(format!("Player {name} has left the adventure")));
-    } else {
-      debug!("No player with ID '{id}' and ZDO index '{zdo_index}' found.");
     }
+    list.save();
+  }
+
+  /// Forgets every player; called when the server starts so the list only reflects this run.
+  pub fn clear() {
+    PlayerList { players: vec![] }.save();
+  }
+
+  /// Names of the players currently online.
+  pub fn online_names() -> Vec<String> {
+    PlayerList::default()
+      .players
+      .into_iter()
+      .map(|p| p.name)
+      .collect()
   }
 }
 
@@ -173,15 +166,17 @@ pub fn handle_player_events(line: &str) {
     Regex::new(r"\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}: Got character ZDOID from (.*) : (\d+:\d+)")
       .expect("Failed to compile joined_regex");
 
-  // Regex to capture player leaving event with player ID and ZDO index
+  // Regex to capture player leaving event with the owning player ID
   let left_regex = Regex::new(
-    r"\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}: Destroying abandoned non persistent zdo (\d+:\d+) owner \d+"
+    r"\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}: Destroying abandoned non persistent zdo \d+:\d+ owner (\d+)"
   ).expect("Failed to compile left_regex");
 
   // Handle player joining event
   if let Some(captures) = joined_regex.captures(line) {
     debug!("Matched joining event: '{captures:?}'");
     match extract_player_details(&captures) {
+      // `0:0` is the character despawning on death, not a join
+      Ok((_, 0, _)) => {}
       Ok((name, id, zdo_index)) => {
         info!("Player '{name}' with ID '{id}' and ZDO index '{zdo_index}' is joining");
         PlayerList::joined_event(id, zdo_index, name);
@@ -193,23 +188,8 @@ pub fn handle_player_events(line: &str) {
   // Handle player leaving event
   if let Some(captures) = left_regex.captures(line) {
     debug!("Matched leaving event: '{captures:?}'");
-    match extract_player_id_and_zdo_index(captures.get(1).map(|m| m.as_str())) {
-      Ok((id, zdo_index)) => {
-        // Check if the ZDO index matches before sending leave event
-        if let Some(player) = PlayerList::get_player_by_id(id) {
-          if player.zdo_index == zdo_index {
-            info!("Player with ID '{id}' and ZDO index '{zdo_index}' is leaving");
-            PlayerList::left_event(id, zdo_index);
-          } else {
-            debug!(
-              "ZDO index mismatch: expected '{}', got '{}'",
-              player.zdo_index, zdo_index
-            );
-          }
-        } else {
-          debug!("Player with ID '{id}' not found");
-        }
-      }
+    match captures[1].parse::<u64>() {
+      Ok(id) => PlayerList::left_event(id),
       Err(e) => error!("Failed to process leaving event line '{line}': {e}"),
     }
   }
@@ -267,29 +247,17 @@ mod tests {
   }
 
   #[test]
-  fn test_update_or_push() {
-    let mut player_list = PlayerList { players: vec![] };
-    let player = Player {
-      id: 1,
-      zdo_index: 0,
-      name: "Player1".to_string(),
-      last_seen: Utc::now().timestamp(),
-    };
+  fn test_join_and_leave() {
+    let mut list = PlayerList { players: vec![] };
+    assert!(list.join(1, 1, "Player1".to_string()));
+    // respawn after death: same player, new zdo index, still one entry, no new join
+    assert!(!list.join(1, 68, "Player1".to_string()));
+    assert_eq!(list.players.len(), 1);
+    assert_eq!(list.players[0].zdo_index, 68);
 
-    player_list.update_or_push(player.clone());
-    assert_eq!(player_list.players.len(), 1);
-    assert_eq!(player_list.players[0].id, player.id);
-    assert_eq!(player_list.players[0].name, player.name);
-
-    let updated_player = Player {
-      id: 1,
-      zdo_index: 0,
-      name: "Player1".to_string(),
-      last_seen: Utc::now().timestamp() + 100,
-    };
-    player_list.update_or_push(updated_player.clone());
-    assert_eq!(player_list.players.len(), 1);
-    assert_eq!(player_list.players[0].last_seen, updated_player.last_seen);
+    assert!(list.leave(2).is_none());
+    assert_eq!(list.leave(1).map(|p| p.name).as_deref(), Some("Player1"));
+    assert!(list.players.is_empty());
   }
 
   #[test]
@@ -314,7 +282,7 @@ mod tests {
     };
     player_list.save();
 
-    PlayerList::left_event(id, 0);
+    PlayerList::left_event(id);
   }
 
   #[test]


### PR DESCRIPTION
## The issue

Huginn's `/players` always answers `"names": []`. It takes the names from the Steam A2S player query, and the Valheim server never fills names into that query (it only registers auth sessions, so Steam reports a count but blank player entries). On an unmodded server the list can never be populated.

Odin already parses the join/leave lines from `valheim_server.log` (`log_filters/player.rs`, behind `PLAYER_EVENT_NOTIFICATIONS`), but its `player.list` cannot be used as an "online" list either:

- a leave only sends the webhook; the player is never removed from the list
- the death line `Got character ZDOID from <name> : 0:0` matches the join regex, so every death is recorded as a join with id 0 and, with webhooks on, announces "Player <name> has joined the adventure!"
- a respawn (same peer, new ZDOID index) is pushed as a second entry and announced as another join
- nothing clears the list when the server starts

## The fix

- **Odin:** `player.list` becomes a presence list. Join replaces any existing entry for that peer id (respawn = update, no duplicate, no second webhook), `0:0` is ignored, leave removes the entry by the `owner <id>` of the `Destroying abandoned non persistent zdo` line, `odin start` clears the file. Tracking now runs unconditionally; `PLAYER_EVENT_NOTIFICATIONS` only gates the webhooks. Each entry also records `joined_at`, kept across respawns. `PlayerList::online()` / `clear()` are exported for Huginn.
- **Huginn:** `/players` fills `names` from that list (A2S kept as a fallback for servers that do publish names) and adds `sessions: [{name, joined_at}]`; `/metrics` adds `valheim_player_online{player="<name>"} 1` and `valheim_player_joined_timestamp_seconds{player="<name>"}` per player online. OpenAPI schema and README updated.

- **Docs:** `docs/metrics.md` lists every metric Huginn emits (linked from the docs README and Huginn's README).

`player.list` stays where it was (saves directory), so nothing changes for existing setups beyond the file now shrinking when players leave.

## Test plan

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets`, `cargo test --workspace` (245 passed; new `test_join_and_leave` covers join → respawn → leave and the preserved `joined_at`).
- Built the image and ran it as a dedicated server: after a player joined, `curl localhost:3000/players` returned `{"online":true,"players":1,"max_players":10,"names":["Viking"],"sessions":[{"name":"Viking","joined_at":1789020710}]}` and `/metrics` contained `valheim_player_online{player="Viking"} 1`; after a death and respawn the entry was unchanged (same `joined_at`); after leaving, `names` and `sessions` were empty; after a server restart `player.list` was `{"players": []}`.



## Why

I made this PR because I wanted to expose the player list in our server's Grafana dashboard!

<img width="2501" height="622" alt="image" src="https://github.com/user-attachments/assets/5ca730ee-d474-4787-872f-f86890f4120c" />
