### PR TITLE
Huginn: report memory and swap in bytes (values were 1024× too large)

### DIFF
--- a/src/shared/src/system.rs
+++ b/src/shared/src/system.rs
@@ -40,10 +40,10 @@ pub fn collect_system_metrics() -> SystemMetrics {
   let load = sysinfo::System::load_average();
 
   SystemMetrics {
-    total_memory_bytes: mem_total * 1024, // sysinfo reports in KiB
-    used_memory_bytes: mem_used * 1024,
-    total_swap_bytes: swap_total * 1024,
-    used_swap_bytes: swap_used * 1024,
+    total_memory_bytes: mem_total,
+    used_memory_bytes: mem_used,
+    total_swap_bytes: swap_total,
+    used_swap_bytes: swap_used,
     total_disk_bytes,
     available_disk_bytes,
     cpu_num_logical: cpus,


### PR DESCRIPTION
## The issue

Huginn's `valheim_sys_memory_total_bytes`, `valheim_sys_memory_used_bytes`, `valheim_sys_swap_total_bytes` and `valheim_sys_swap_used_bytes` are 1024× too large: on an 8 GB host `valheim_sys_memory_total_bytes` reads `8317225140224` (8.3 TB).

`collect_system_metrics` multiplies sysinfo's values by 1024 with the comment `// sysinfo reports in KiB`. That was true up to sysinfo 0.29; since 0.30 `System::total_memory()`, `used_memory()`, `total_swap()` and `used_swap()` return **bytes**, and the workspace is on sysinfo 0.39.6.

## The fix

- Drop the `* 1024` on the four memory/swap fields in `src/shared/src/system.rs`. Disk values were already bytes.

## Test plan

- `cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt --check` pass.
- Running the image on an 8 GB host: `curl localhost:3000/metrics | grep memory_total` gives `valheim_sys_memory_total_bytes 8122290176` (matches `free -b`), previously `8317225140224`.