### PR TITLE
fix(huginn): report memory and swap in bytes (from @ksc98) + a regression test

### DIFF
--- a/src/shared/src/system.rs
+++ b/src/shared/src/system.rs
@@ -177,3 +177,71 @@ pub fn format_perm_summary(perm: &PermSummary) -> String {
     if perm.can_write { "yes" } else { "no" },
   )
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// Reads a `/proc/meminfo` field, which the kernel reports in KiB.
+  #[cfg(target_os = "linux")]
+  fn meminfo_kib(field: &str) -> Option<u64> {
+    let contents = std::fs::read_to_string("/proc/meminfo").ok()?;
+    contents.lines().find_map(|line| {
+      let rest = line.strip_prefix(field)?.strip_prefix(':')?;
+      rest.split_whitespace().next()?.parse::<u64>().ok()
+    })
+  }
+
+  /// sysinfo returned KiB up to 0.29 and bytes from 0.30 on, so a version
+  /// bump silently multiplied every memory metric by 1024 — `/metrics`
+  /// reported 8.3 TB on an 8 GB host (#1514). Compare what we publish
+  /// against the kernel's own number rather than against whichever unit
+  /// sysinfo currently uses.
+  #[cfg(target_os = "linux")]
+  #[test]
+  fn memory_and_swap_are_reported_in_bytes() {
+    let Some(mem_total_kib) = meminfo_kib("MemTotal") else {
+      // No /proc/meminfo (an unusual container): nothing to compare to.
+      return;
+    };
+    let metrics = collect_system_metrics();
+    let kernel_bytes = mem_total_kib * 1024;
+
+    // sysinfo and the kernel can disagree slightly (sysinfo excludes some
+    // reserved regions), so allow a few percent, but nothing near the
+    // 1024x a unit mix-up produces.
+    let difference = metrics.total_memory_bytes.abs_diff(kernel_bytes);
+    assert!(
+      difference * 20 < kernel_bytes,
+      "total_memory_bytes {} is not within 5% of MemTotal {} bytes — check the unit sysinfo reports",
+      metrics.total_memory_bytes,
+      kernel_bytes
+    );
+
+    // Used memory is a subset of total, which a stray multiplier breaks
+    // even on a host whose MemTotal we couldn't read.
+    assert!(
+      metrics.used_memory_bytes <= metrics.total_memory_bytes,
+      "used_memory_bytes {} exceeds total_memory_bytes {}",
+      metrics.used_memory_bytes,
+      metrics.total_memory_bytes
+    );
+
+    if let Some(swap_total_kib) = meminfo_kib("SwapTotal") {
+      let kernel_swap_bytes = swap_total_kib * 1024;
+      let difference = metrics.total_swap_bytes.abs_diff(kernel_swap_bytes);
+      assert!(
+        difference * 20 < kernel_swap_bytes.max(1),
+        "total_swap_bytes {} is not within 5% of SwapTotal {} bytes",
+        metrics.total_swap_bytes,
+        kernel_swap_bytes
+      );
+    }
+    assert!(
+      metrics.used_swap_bytes <= metrics.total_swap_bytes,
+      "used_swap_bytes {} exceeds total_swap_bytes {}",
+      metrics.used_swap_bytes,
+      metrics.total_swap_bytes
+    );
+  }
+}

--- a/src/shared/src/system.rs
+++ b/src/shared/src/system.rs
@@ -40,10 +40,10 @@ pub fn collect_system_metrics() -> SystemMetrics {
   let load = sysinfo::System::load_average();
 
   SystemMetrics {
-    total_memory_bytes: mem_total * 1024, // sysinfo reports in KiB
-    used_memory_bytes: mem_used * 1024,
-    total_swap_bytes: swap_total * 1024,
-    used_swap_bytes: swap_used * 1024,
+    total_memory_bytes: mem_total,
+    used_memory_bytes: mem_used,
+    total_swap_bytes: swap_total,
+    used_swap_bytes: swap_used,
     total_disk_bytes,
     available_disk_bytes,
     cpu_num_logical: cpus,


### PR DESCRIPTION
# Description

Takes in [#1514](https://github.com/mbround18/valheim-docker/pull/1514) from @ksc98 — their commit is merged here unchanged, so please **merge, don't squash**, to keep their authorship — and adds a regression test for it.

## Their fix

`collect_system_metrics` multiplied memory and swap by 1024 with the comment `// sysinfo reports in KiB`. That held up to sysinfo 0.29; from 0.30 on, `total_memory()`, `used_memory()`, `total_swap()` and `used_swap()` return bytes, and the workspace is on 0.39.6. So every memory metric was 1024× too large — an 8 GB host reported `valheim_sys_memory_total_bytes 8317225140224`, or 8.3 TB.

I confirmed it against this branch: sysinfo 0.39.6's `total_memory()` matches `/proc/meminfo`'s `MemTotal` in bytes, so the multiplier is the whole bug. Disk values were always bytes and are untouched.

It also affected odin's preflight log line, which reported memory in TiB (`src/odin/server/install.rs`). Nothing gates on these values — no threshold, alert or dashboard in the repo compensated for the inflated numbers — so this is a straight reporting fix with no downstream adjustment needed.

## What I added

A test that pins the units to the kernel's own numbers rather than to whichever unit sysinfo currently uses, so the next dependency bump can't repeat this silently:

- total memory within 5% of `/proc/meminfo`'s `MemTotal`, and total swap within 5% of `SwapTotal` (sysinfo excludes some reserved regions, so it is never exactly equal — but never off by 1024× either);
- used never above total, for memory and swap;
- skipped where `/proc/meminfo` isn't readable, and Linux-only.

Reintroducing the `* 1024` fails it: `total_memory_bytes 34363488075776 is not within 5% of MemTotal 33558093824 bytes`.

## Testing

- `cargo test --workspace` passes; the new test fails as shown above when the multiplier is put back.
- `cargo clippy --workspace --all-targets -D warnings` and `cargo fmt --check` pass.

## Checklist

- [x] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [ ] This PR has a reviewer on it.
- [ ] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
