### PR TITLE
odin: refuse to start into an unwritable save directory; alert on failed world saves

### DIFF
--- a/docs/tutorials/rootless_design.md
+++ b/docs/tutorials/rootless_design.md
@@ -48,6 +48,16 @@ starts under a uid that has an account in the image (see
 [below](#upgrading-from-images-where-steam-was-uid-111)). Give your host user access to the
 volumes through the group instead; see [Group File System Access](./group_file_system_access.md).
 
+## What Happens When a Volume Is Not Writable
+
+Odin refuses to start when the game or Steam directories are not writable
+(`Preflight write check failed`) and, since the save directory is checked too, when
+`worlds_local/<world>` is not writable (`Save directory is not writable`). The second check
+matters: the Valheim server itself keeps running when it cannot save, logging
+`Error saving world!` on every save interval while the world on disk (and every backup taken
+from it) stays stale. Fix the ownership of the mounted volumes rather than working around the
+check.
+
 ## Migration Checklist
 
 1. Stop the running container.

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -32,6 +32,17 @@
 | `event_message`     | A description of the event. |
 | `timestamp`         | ISO8601 timestamp           |
 
+## World Save Failures
+
+Valheim keeps running when it cannot write its world (for example when the mounted save
+volume is owned by another user): it logs `Error saving world!` and carries on in memory,
+so the only visible symptom is a stale world after the next restart. Odin logs that line
+at `ERROR` and sends a `Save Failed` notification on the first failure of a streak, then
+`Save Successful` once a save goes through again. Both use the `WEBHOOK_STATUS_FAILED` /
+`WEBHOOK_STATUS_SUCCESSFUL` switches. Odin also refuses to start the server at all when the
+save directory is not writable, since a server that cannot save is worse than one that
+does not start.
+
 ## Silencing Discord Notifications
 
 Player join/leave events can make a busy server noisy. Setting

--- a/src/odin/commands/logs.rs
+++ b/src/odin/commands/logs.rs
@@ -1,4 +1,4 @@
-use crate::log_filters::{handle_launch_probes, handle_player_events};
+use crate::log_filters::{handle_launch_probes, handle_player_events, handle_save_events};
 use crate::utils::common_paths::log_directory;
 use crate::utils::environment::is_env_var_truthy;
 use anyhow::{Context, Result};
@@ -72,6 +72,7 @@ fn handle_line_core(path: &PathBuf, line: &str) {
   }
 
   handle_player_events(line);
+  handle_save_events(line);
 
   let file_name = match path.file_name().and_then(|name| name.to_str()) {
     Some(name) => name,
@@ -98,7 +99,7 @@ fn handle_line_core(path: &PathBuf, line: &str) {
 
   let level = if line.contains("WARNING") {
     Level::Warn
-  } else if line.contains("ERROR") {
+  } else if line.contains("ERROR") || line.contains("Error saving world!") {
     Level::Error
   } else if line.contains("Fallback handler could not load library") {
     Level::Debug

--- a/src/odin/commands/start.rs
+++ b/src/odin/commands/start.rs
@@ -17,6 +17,18 @@ pub fn invoke(dry_run: bool) {
   debug!(target: "commands_start", "Dry run condition: {dry_run}");
   info!(target: "commands_start", "Looking for burial mounds...");
   if !dry_run {
+    if let Err(e) = server::save_directory_write_checks() {
+      error!(target: "commands_start", "Save directory is not writable: {e}");
+      error!(
+        target: "commands_start",
+        "The server would start, but every world save would fail and progress would be lost on restart."
+      );
+      error!(
+        target: "commands_start",
+        "Make the mounted save volume writable by the container's uid:gid (for example `chown -R` it on the host)."
+      );
+      exit(1);
+    }
     match server::start_daemonized(config) {
       Ok(_) => info!(target: "commands_start", "Success, daemonized"),
       Err(e) => {

--- a/src/odin/log_filters/mod.rs
+++ b/src/odin/log_filters/mod.rs
@@ -1,5 +1,7 @@
 mod player;
 mod probes;
+mod save;
 
 pub use player::{handle_player_events, OnlinePlayer, PlayerList};
 pub use probes::handle_launch_probes;
+pub use save::handle_save_events;

--- a/src/odin/log_filters/save.rs
+++ b/src/odin/log_filters/save.rs
@@ -1,0 +1,68 @@
+use crate::notifications::enums::{
+  event_status::EventStatus, notification_event::NotificationEvent,
+};
+use log::{error, info};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+const SAVE_FAILED: &str = "Error saving world!";
+const SAVE_DONE: &str = "World save (";
+
+/// Whether the last world save failed. Only the first failure of a streak sends a webhook,
+/// since the game retries on every save interval.
+static SAVE_FAILING: AtomicBool = AtomicBool::new(false);
+
+/// Surfaces failed world saves. Valheim logs `Error saving world! <reason>` and keeps
+/// running, so without this the only sign is a stale world after the next restart.
+pub fn handle_save_events(line: &str) {
+  if let Some(pos) = line.find(SAVE_FAILED) {
+    let reason = line[pos + SAVE_FAILED.len()..]
+      .split("StackTrace:")
+      .next()
+      .unwrap_or("")
+      .trim();
+    error!("World save failed! The server keeps running but progress is not being written to disk: {reason}");
+    if !SAVE_FAILING.swap(true, Ordering::SeqCst) {
+      NotificationEvent::Save(EventStatus::Failed)
+        .send_notification(Some(format!("World save failed: {reason}")));
+    }
+  } else if line.contains(SAVE_DONE)
+    && line.contains("done. Total time")
+    && SAVE_FAILING.swap(false, Ordering::SeqCst)
+  {
+    info!("World save succeeded again.");
+    NotificationEvent::Save(EventStatus::Successful)
+      .send_notification(Some("World save succeeded again".to_string()));
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use serial_test::serial;
+
+  const FAILED_LINE: &str = "09/11/2026 19:26:13: Error saving world! Access to the path \"/home/steam/.config/unity3d/IronGate/Valheim/worlds_local/Dedicated/00_00__0_3.chunk\" is denied.  StackTrace:   at System.IO.FileStream..ctor (System.String path) [0x0019e] in <297b518d2c9f4ee5bb6b049e9ead4f70>:0 ";
+  const DONE_LINE: &str = "09/11/2026 19:21:39: World save (5/5) done. Total time [13ms]";
+
+  #[test]
+  #[serial]
+  fn failure_sets_the_flag_and_success_clears_it() {
+    std::env::remove_var("WEBHOOK_URL");
+    SAVE_FAILING.store(false, Ordering::SeqCst);
+    handle_save_events(FAILED_LINE);
+    assert!(SAVE_FAILING.load(Ordering::SeqCst));
+    handle_save_events(FAILED_LINE);
+    assert!(SAVE_FAILING.load(Ordering::SeqCst));
+    handle_save_events(DONE_LINE);
+    assert!(!SAVE_FAILING.load(Ordering::SeqCst));
+  }
+
+  #[test]
+  #[serial]
+  fn unrelated_lines_are_ignored() {
+    std::env::remove_var("WEBHOOK_URL");
+    SAVE_FAILING.store(false, Ordering::SeqCst);
+    handle_save_events("09/11/2026 19:21:39: World save (2/5) Chunks writing done [2ms]");
+    handle_save_events("09/11/2026 19:19:46: Game server connected");
+    assert!(!SAVE_FAILING.load(Ordering::SeqCst));
+  }
+}

--- a/src/odin/notifications/enums/notification_event.rs
+++ b/src/odin/notifications/enums/notification_event.rs
@@ -20,6 +20,7 @@ pub enum NotificationEvent {
   Update(EventStatus),
   Start(EventStatus),
   Stop(EventStatus),
+  Save(EventStatus),
   Player(PlayerStatus),
 }
 
@@ -179,7 +180,7 @@ impl fmt::Display for NotificationEvent {
 impl std::str::FromStr for NotificationEvent {
   type Err = VariantNotFound;
   fn from_str(s: &str) -> Result<NotificationEvent, Self::Err> {
-    use NotificationEvent::{Broadcast, Player, Start, Stop, Update};
+    use NotificationEvent::{Broadcast, Player, Save, Start, Stop, Update};
     let parts: Vec<&str> = s.split(' ').collect();
     let event = parts[0];
     if event.eq(Broadcast.to_string().as_str()) {
@@ -194,6 +195,7 @@ impl std::str::FromStr for NotificationEvent {
         "Update" => Ok(Update(event_status)),
         "Start" => Ok(Start(event_status)),
         "Stop" => Ok(Stop(event_status)),
+        "Save" => Ok(Save(event_status)),
         _ => Err(VariantNotFound {
           v: String::from("Failed to find Notification Event"),
         }),

--- a/src/odin/server/install.rs
+++ b/src/odin/server/install.rs
@@ -793,10 +793,6 @@ pub(crate) fn reset_download_state(install_dir: &Path, app_id: i64) -> Result<Ve
 }
 
 fn preflight_write_checks(staged_install: bool) -> Result<(), String> {
-  use std::fs::{remove_file, OpenOptions};
-  use std::io::Write;
-  use std::time::{SystemTime, UNIX_EPOCH};
-
   let workdir = get_working_dir();
   let paths = vec![
     "/home/steam/Steam".to_string(),
@@ -816,6 +812,30 @@ fn preflight_write_checks(staged_install: bool) -> Result<(), String> {
     paths.push("/home/steam/.staging".to_string());
   }
 
+  write_checks(&paths)?;
+  save_directory_write_checks()
+}
+
+/// The directories the game writes its world into. Valheim keeps running when a save fails
+/// (it logs `Error saving world!` and carries on in memory), so an unwritable save directory
+/// means every autosave silently fails and a restart loads a stale world.
+pub fn save_directory_write_checks() -> Result<(), String> {
+  let saves = common_paths::saves_directory();
+  let worlds = format!("{saves}/worlds_local");
+  let mut paths = vec![saves, worlds.clone()];
+  let world = environment::fetch_var("WORLD", "");
+  if !world.is_empty() {
+    paths.push(format!("{worlds}/{world}"));
+  }
+  write_checks(&paths)
+}
+
+/// Probe each existing directory with a temporary file; missing paths are skipped.
+fn write_checks(paths: &[String]) -> Result<(), String> {
+  use std::fs::{remove_file, OpenOptions};
+  use std::io::Write;
+  use std::time::{SystemTime, UNIX_EPOCH};
+
   let now_ns = SystemTime::now()
     .duration_since(UNIX_EPOCH)
     .map_err(|e| e.to_string())?
@@ -823,7 +843,7 @@ fn preflight_write_checks(staged_install: bool) -> Result<(), String> {
 
   for p in paths {
     debug!("Testing write access: {}", p);
-    let dir = Path::new(&p);
+    let dir = Path::new(p);
     if !dir.exists() {
       debug!("Skipping write check (missing): {}", p);
       continue;
@@ -980,6 +1000,33 @@ mod tests {
   use std::fs;
   use tempfile::tempdir;
   use test_case::test_case;
+
+  #[test]
+  #[serial_test::serial]
+  fn save_directory_write_checks_probe_the_world_directory() {
+    use std::os::unix::fs::PermissionsExt;
+    let saves = tempdir().unwrap();
+    let world = saves.path().join("worlds_local").join("Dedicated");
+    fs::create_dir_all(&world).unwrap();
+    env::set_var("SAVE_LOCATION", saves.path());
+    env::set_var("WORLD", "Dedicated");
+
+    assert!(save_directory_write_checks().is_ok());
+
+    // Root ignores directory modes, so the negative case only holds for other users.
+    fs::set_permissions(&world, fs::Permissions::from_mode(0o555)).unwrap();
+    let probe = world.join("probe");
+    let unprivileged = fs::File::create(&probe).is_err();
+    if unprivileged {
+      let err = save_directory_write_checks().unwrap_err();
+      assert!(err.contains("worlds_local/Dedicated"), "{err}");
+    }
+    fs::set_permissions(&world, fs::Permissions::from_mode(0o755)).unwrap();
+    let _ = fs::remove_file(probe);
+
+    env::remove_var("SAVE_LOCATION");
+    env::remove_var("WORLD");
+  }
 
   #[test_case(
     false,


### PR DESCRIPTION
## The issue

When the Valheim server cannot write its world (typically a mounted save volume owned by a different uid than the container runs as), **it keeps running**. It loads the world, reports `Game server connected`, the healthcheck stays `healthy`, players join and play, and every save interval it logs

```
Error saving world! Access to the path "/home/steam/.config/unity3d/IronGate/Valheim/worlds_local/<world>/00_00__0_3.chunk" is denied.  StackTrace: ...
```

and carries on in memory. The world on disk, and every backup Odin takes of it, stay at the state they had when the server loaded. The first visible symptom is the next restart loading a stale world, by which time the progress is gone. Nothing in the container surfaced this: the entrypoint's `Path is not writable by runtime user` is an INFO line that only checks the top of `SAVE_LOCATION`, `odin install`'s preflight checks the Steam, game and backup directories but not the save directory, and `odin logs` printed the game's line at INFO.

Reported as #1515 (reproduced with the 3.8.0 image, Valheim 1.0, `user: 1000:1000` and a root-owned `worlds_local/<world>` in a container where the entrypoint's `sudo chown` cannot run).

## The fix

- `odin start` (and `odin install`'s preflight) now probe `SAVE_LOCATION`, `worlds_local` and `worlds_local/<WORLD>` for writability and refuse to launch the server when one is not writable, with an error saying what to fix. A server that cannot save is worse than one that does not start.
- A log filter logs `Error saving world!` at `ERROR` and sends a `Save Failed` webhook on the first failure of a streak, then `Save Successful` once a save goes through again (gated by the existing `WEBHOOK_STATUS_FAILED` / `WEBHOOK_STATUS_SUCCESSFUL` switches). `NotificationEvent` gains a `Save(EventStatus)` variant.
- Docs: `docs/webhooks.md` and `docs/tutorials/rootless_design.md` describe both behaviours.

## Test plan

- `cargo fmt`, `cargo clippy --all-targets` (clean), `cargo test --all` (287 tests pass, including the new `save_directory_write_checks_probe_the_world_directory` and the two `log_filters::save` tests).
- `npx prettier --check` on the two edited docs.
- Built the `valheim` target locally and ran it with the real game (Valheim 1.0) as `--user 1000:1000 --security-opt no-new-privileges` (so the entrypoint's chown is skipped, as in rootless Podman / hardened setups):
  - With `worlds_local/<world>` owned by root: `odin start` exits 1 with `Save directory is not writable: WRITE FAIL .../worlds_local: Permission denied (os error 13)` and the container stops instead of running a server that cannot save.
  - With a writable world dir, then chowning it to root while the server runs: the next autosave produces `ERROR odin::log_filters::save: World save failed! ... Access to the path ... is denied.` in `docker logs` and one `Save Failed` POST reaches the webhook; restoring ownership produces `Save Successful` on the next save.
