### PR TITLE
ci: build the Docker images on fork pull requests without DockerHub credentials

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -74,6 +74,10 @@ jobs:
   build_docker:
     name: "Build Docker"
     runs-on: ubuntu-latest
+    env:
+      # Pull requests from forks receive no repository secrets, so they can build and
+      # check the image but cannot log in to DockerHub, push, or upload the build cache.
+      IN_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     strategy:
       fail-fast: true
       matrix:
@@ -90,6 +94,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
+        if: env.IN_REPO == 'true'
         uses: docker/login-action@v4
         with:
           username: mbround18
@@ -110,12 +115,12 @@ jobs:
         with:
           file: ./Dockerfile
           target: ${{ matrix.image }}
-          push: ${{ matrix.push }}
+          push: ${{ env.IN_REPO == 'true' && matrix.push }}
           load: ${{ matrix.image == 'valheim' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=mbround18/${{ matrix.image }}:buildcache
-          cache-to: type=registry,ref=mbround18/${{ matrix.image }}:buildcache,mode=max
+          cache-to: ${{ env.IN_REPO == 'true' && format('type=registry,ref=mbround18/{0}:buildcache,mode=max', matrix.image) || '' }}
           build-args: |
             "GITHUB_SHA=${GITHUB_SHA}"
             "GITHUB_REF=${GITHUB_REF}"
@@ -127,7 +132,7 @@ jobs:
         run: bash ./.github/scripts/check-image-permissions.sh "${{ fromJSON(steps.meta.outputs.json).tags[0] }}"
 
       - name: Publish Image Summary
-        if: matrix.push
+        if: env.IN_REPO == 'true' && matrix.push
         run: |
           {
             echo "\`\`\`";


### PR DESCRIPTION
## The issue

On a pull request from a fork, the `Build Docker` job fails after ~10 s at the **Login to DockerHub** step:

```
##[error]Password required
```

Fork PRs receive no repository secrets, so `secrets.DOCKER_TOKEN` is empty, the login fails before any build starts, and `fail-fast` cancels the other matrix leg. Seen on #1518 (and every other fork PR); the same workflow passes on in-repo branches.

## The fix

- The `build_docker` job sets `IN_REPO` from `github.event.pull_request.head.repo.full_name == github.repository`.
- The DockerHub login, the `push`, the registry `cache-to` upload and the image summary run only when `IN_REPO` is true. `cache-from` stays, since pulling the public build cache needs no credentials.
- Fork PRs still build both images, `load` the valheim image and run `check-image-permissions.sh` against it, so the Dockerfile and image layout are checked; nothing is published from them.

## Test plan

- `actionlint` on the workflow reports only the two pre-existing shellcheck notes in the summary scripts.
- `prettier --check` on the workflow passes.
- This PR is itself from a fork: its own `Build Docker (odin)` and `Build Docker (valheim)` checks exercise the new path.