### PR TITLE
ci: pin paws to v0.0.1-prerelease.50 for the release-asset fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: mbround18/paws/actions/paws-up@v0.0.1-prerelease.49
+      - uses: mbround18/paws/actions/paws-up@v0.0.1-prerelease.50
         with:
-          version: v0.0.1-prerelease.49
+          version: v0.0.1-prerelease.50
       # cargo fmt --check, clippy -D warnings, build and test, in rust:1-bookworm.
       - run: paws ci --toolchain rust
 
@@ -39,9 +39,9 @@ jobs:
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-      - uses: mbround18/paws/actions/paws-up@v0.0.1-prerelease.49
+      - uses: mbround18/paws/actions/paws-up@v0.0.1-prerelease.50
         with:
-          version: v0.0.1-prerelease.49
+          version: v0.0.1-prerelease.50
       # Both images in one paws call (prerelease.48): valheim copies odin and huginn from
       # the odin stage, so building them against one engine compiles the Rust workspace
       # once. Builds on every run. Pushes :<sha> tags on main, and on a PR only with the
@@ -91,9 +91,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: mbround18/paws/actions/paws-up@v0.0.1-prerelease.49
+      - uses: mbround18/paws/actions/paws-up@v0.0.1-prerelease.50
         with:
-          version: v0.0.1-prerelease.49
+          version: v0.0.1-prerelease.50
       - name: Next version (not tagged)
         id: semver
         env:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -22,9 +22,9 @@ jobs:
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-      - uses: mbround18/paws/actions/paws-up@v0.0.1-prerelease.49
+      - uses: mbround18/paws/actions/paws-up@v0.0.1-prerelease.50
         with:
-          version: v0.0.1-prerelease.49
+          version: v0.0.1-prerelease.50
       # One paws call for both images, against one Dagger engine. The Dockerfile compiles
       # odin and huginn once, in odin-builder, and valheim copies them from the odin stage,
       # so the valheim build reuses the layers the odin build just made. A call per image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,9 +73,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: mbround18/paws/actions/paws-up@v0.0.1-prerelease.49
+      - uses: mbround18/paws/actions/paws-up@v0.0.1-prerelease.50
         with:
-          version: v0.0.1-prerelease.49
+          version: v0.0.1-prerelease.50
       # Resolve the version from the merged PR's major/minor/patch label without
       # tagging anything yet.
       - name: Next version (not tagged yet)

--- a/docs/spikes/paws-ci.md
+++ b/docs/spikes/paws-ci.md
@@ -105,7 +105,7 @@ The last row is slower for a reason unrelated to the single call. `.dockerignore
 - **Images publish from the release tag, not from `main`.** `paws docker` only adds `:latest` and the rollup tags when `GITHUB_REF` is a tag, so publishing in the same run as `paws semver --push`, a push to `main`, would silently skip them. `images.yml` runs on the `v*` tag push instead. That tag has to be created with a personal token (`GH_TOKEN`), because GitHub doesn't start workflows for tags pushed with the built-in `GITHUB_TOKEN`.
 - A release image no longer gets a `sha-<sha>` tag. `--tag-sha` only adds one when `--version` is itself a sha, which a release version isn't.
 
-11. **Pin paws. Done.** `paws-up@main` with `version: latest` resolves to the newest _prerelease_, so every workflow now uses `mbround18/paws/actions/paws-up@v0.0.1-prerelease.49` with `version: v0.0.1-prerelease.49`. That pins both the action and the binary it installs. Moving to a newer paws is a deliberate edit to those lines. Pinning the action to a commit SHA instead of the tag would also protect against the tag being moved.
+11. **Pin paws. Done.** `paws-up@main` with `version: latest` resolves to the newest _prerelease_, so every workflow now uses `mbround18/paws/actions/paws-up@v0.0.1-prerelease.50` with `version: v0.0.1-prerelease.50`. That pins both the action and the binary it installs. Moving to a newer paws is a deliberate edit to those lines. Pinning the action to a commit SHA instead of the tag would also protect against the tag being moved.
 
 ## Not proven by the spike
 
@@ -116,6 +116,6 @@ The publishing workflows can't run from a PR. `release.yml` runs on `main` (`sem
 paws can take over both halves:
 
 - **Build side:** `paws ci` matched the current Rust job exactly, and `paws docker` built the images.
-- **Release side:** both blockers are fixed upstream. The changelog is one line per PR (gap 1, `prerelease.45`), and releases keep the existing unprefixed image tags (gap 6, `prerelease.46`). Building both images in one job needed the cache fix in `prerelease.47`, and they now build in a single call thanks to `prerelease.48` (gap 3). The spike is pinned to `prerelease.49`.
+- **Release side:** both blockers are fixed upstream. The changelog is one line per PR (gap 1, `prerelease.45`), and releases keep the existing unprefixed image tags (gap 6, `prerelease.46`). Building both images in one job needed the cache fix in `prerelease.47`, and they now build in a single call thanks to `prerelease.48` (gap 3). The spike is pinned to `prerelease.50`.
 
 Gaps 2–5 are rough edges, not blockers. Watch the first release closely: it's the first time the publishing half runs for real.


### PR DESCRIPTION
# Description

Pins every `paws-up` step to `v0.0.1-prerelease.50`, which carries mbround18/paws#35.

## What it fixes

v3.8.2 released correctly — tag, GitHub Release, changelog, both images with their OCI labels — and then the run failed at the very last step:

```
Error: odin+huginn-3.8.2-x86_64-unknown-linux-gnu.zip was uploaded, but it is not
on the release that tag v3.8.2 resolves to (release 387491843).
```

GitHub rewrites characters outside `A-Za-z0-9._-` in an uploaded asset's name, so that archive is stored as `odin.huginn-3.8.2-x86_64-unknown-linux-gnu.zip`. paws looked for the name it had uploaded and missed it. The archive was on the release the whole time.

The same lookup guards the clobber path, so until this pin lands, re-running a release would add a second copy of the archive instead of replacing the first.

## Testing

No repo code changes — this is a pin bump. CI exercises `paws ci`, both image builds and the release rehearsal against the new version.

## Checklist

- [x] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [ ] This PR has a reviewer on it.
- [ ] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
