### PR TITLE
fix(odin): refuse to start into an unwritable save directory (from @ksc98) + a container regression test

### DIFF
--- a/.github/scripts/save-dir-preflight-test.sh
+++ b/.github/scripts/save-dir-preflight-test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Reproduces #1515 against a built image: a save volume the container's uid cannot write.
+#
+# Valheim keeps running when it cannot save — it logs `Error saving world!` every save
+# interval and carries on in memory, so the world on disk and every backup taken from it
+# stay stale until a restart loads that stale world. `odin start` refuses to launch into
+# that state, and this checks it still does.
+#
+# Usage: ./.github/scripts/save-dir-preflight-test.sh <image>
+set -euo pipefail
+
+IMAGE="${1:-valheim-docker:ci}"
+SAVES="$(mktemp -d)"
+WORLD_DIR="$SAVES/worlds_local/Dedicated"
+mkdir -p "$WORLD_DIR"
+trap 'chmod -R u+w "$SAVES" 2>/dev/null || true; rm -rf "$SAVES"' EXIT
+
+# The container runs as 1000:1000 below, so the host side has to be owned by a uid the
+# check can fail against. Refuse to run as root, where mode bits are ignored and every
+# case would pass.
+if [ "$(id -u)" -eq 0 ]; then
+  echo "::error::run this as a non-root user; root ignores directory modes"
+  exit 1
+fi
+
+# `odin start` loads its config before checking anything, and `odin configure` insists on a
+# server executable, so stub one. It is never launched in the failing case, and in the
+# passing case it exits immediately.
+odin_start() {
+  docker run --rm --user 1000:1000 \
+    -e SAVE_LOCATION=/saves -e WORLD=Dedicated \
+    -v "$SAVES:/saves" --entrypoint bash "$IMAGE" -c '
+      printf "#!/bin/sh\nexit 0\n" > /home/steam/valheim/valheim_server.x86_64
+      chmod +x /home/steam/valheim/valheim_server.x86_64
+      odin configure --password "Str0ngPassw0rd" --name preflight-probe >/dev/null 2>&1 \
+        || { echo "odin configure failed"; exit 9; }
+      odin start 2>&1
+      exit ${PIPESTATUS[0]}'
+}
+
+echo "==> An unwritable world directory must stop the server from starting"
+chmod 555 "$WORLD_DIR"
+set +e
+output="$(odin_start)"
+rc=$?
+set -e
+echo "$output" | tail -5
+if [ "$rc" -eq 0 ]; then
+  echo "::error::odin start succeeded with an unwritable save directory (regression of #1515)"
+  exit 1
+fi
+if ! grep -q "Save directory is not writable" <<<"$output"; then
+  echo "::error::odin start failed, but not with the save-directory message — check what broke"
+  exit 1
+fi
+grep -q "worlds_local/Dedicated" <<<"$output" || {
+  echo "::error::the error does not name the directory at fault, which is what makes it fixable"
+  exit 1
+}
+echo "    refused to start, naming the directory: ok"
+
+echo "==> A writable world directory must let the server start"
+chmod 755 "$WORLD_DIR"
+set +e
+output="$(odin_start)"
+rc=$?
+set -e
+if [ "$rc" -ne 0 ] || grep -q "Save directory is not writable" <<<"$output"; then
+  echo "$output" | tail -5
+  echo "::error::the check rejected a writable save directory"
+  exit 1
+fi
+echo "    started: ok"
+
+echo "==> The write probes must not leave files behind"
+leftovers="$(find "$SAVES" -name '.write_test_*' -print)"
+if [ -n "$leftovers" ]; then
+  echo "::error::probe files left in the save volume: $leftovers"
+  exit 1
+fi
+echo "    save volume is clean: ok"
+
+echo "All save-directory preflight checks passed."

--- a/.github/scripts/save-dir-preflight-test.sh
+++ b/.github/scripts/save-dir-preflight-test.sh
@@ -10,24 +10,32 @@
 set -euo pipefail
 
 IMAGE="${1:-valheim-docker:ci}"
+# The container runs as the image's own steam uid, which owns /home/steam — `odin
+# configure` writes there, so no other uid gets far enough to reach the check. It is not
+# assumed to own the *host* directories: on a CI runner it does not, which is the same
+# ownership mismatch that produces this bug in the first place, so the modes below are set
+# for "other" rather than for the owner.
+PROBE_UID=1000
 SAVES="$(mktemp -d)"
 WORLD_DIR="$SAVES/worlds_local/Dedicated"
 mkdir -p "$WORLD_DIR"
-trap 'chmod -R u+w "$SAVES" 2>/dev/null || true; rm -rf "$SAVES"' EXIT
+trap 'chmod -R u+rwx "$SAVES" 2>/dev/null || true; rm -rf "$SAVES"' EXIT
 
-# The container runs as 1000:1000 below, so the host side has to be owned by a uid the
-# check can fail against. Refuse to run as root, where mode bits are ignored and every
-# case would pass.
+# Root ignores directory modes, so every case would pass and prove nothing.
 if [ "$(id -u)" -eq 0 ]; then
   echo "::error::run this as a non-root user; root ignores directory modes"
   exit 1
 fi
 
+# Everything above the world directory has to be writable by the container's uid, whoever
+# owns it on the host, so that the world directory is the only thing under test.
+chmod 777 "$SAVES" "$SAVES/worlds_local"
+
 # `odin start` loads its config before checking anything, and `odin configure` insists on a
 # server executable, so stub one. It is never launched in the failing case, and in the
 # passing case it exits immediately.
 odin_start() {
-  docker run --rm --user 1000:1000 \
+  docker run --rm --user "$PROBE_UID:$PROBE_UID" \
     -e SAVE_LOCATION=/saves -e WORLD=Dedicated \
     -v "$SAVES:/saves" --entrypoint bash "$IMAGE" -c '
       printf "#!/bin/sh\nexit 0\n" > /home/steam/valheim/valheim_server.x86_64
@@ -39,6 +47,7 @@ odin_start() {
 }
 
 echo "==> An unwritable world directory must stop the server from starting"
+# r-x for everyone: the owner can still read it, nobody can write it.
 chmod 555 "$WORLD_DIR"
 set +e
 output="$(odin_start)"
@@ -60,7 +69,8 @@ grep -q "worlds_local/Dedicated" <<<"$output" || {
 echo "    refused to start, naming the directory: ok"
 
 echo "==> A writable world directory must let the server start"
-chmod 755 "$WORLD_DIR"
+# World-writable rather than 755: the container's uid does not own this directory.
+chmod 777 "$WORLD_DIR"
 set +e
 output="$(odin_start)"
 rc=$?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,10 @@ jobs:
         run: docker buildx build --load --target valheim -t valheim-docker:ci .
       - name: Image permissions
         run: ./.github/scripts/check-image-permissions.sh valheim-docker:ci
+      # Reproduces #1515: a save volume the container's uid cannot write. Cheap — it never
+      # installs the game — so it runs on every PR, unlike the full container e2e below.
+      - name: Save-directory preflight
+        run: ./.github/scripts/save-dir-preflight-test.sh valheim-docker:ci
       # Downloads the ~2 GB dedicated server, so only on demand.
       - name: Container end-to-end
         if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'e2e')

--- a/docs/tutorials/rootless_design.md
+++ b/docs/tutorials/rootless_design.md
@@ -48,6 +48,16 @@ starts under a uid that has an account in the image (see
 [below](#upgrading-from-images-where-steam-was-uid-111)). Give your host user access to the
 volumes through the group instead; see [Group File System Access](./group_file_system_access.md).
 
+## What Happens When a Volume Is Not Writable
+
+Odin refuses to start when the game or Steam directories are not writable
+(`Preflight write check failed`) and, since the save directory is checked too, when
+`worlds_local/<world>` is not writable (`Save directory is not writable`). The second check
+matters: the Valheim server itself keeps running when it cannot save, logging
+`Error saving world!` on every save interval while the world on disk (and every backup taken
+from it) stays stale. Fix the ownership of the mounted volumes rather than working around the
+check.
+
 ## Migration Checklist
 
 1. Stop the running container.

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -32,6 +32,17 @@
 | `event_message`     | A description of the event. |
 | `timestamp`         | ISO8601 timestamp           |
 
+## World Save Failures
+
+Valheim keeps running when it cannot write its world (for example when the mounted save
+volume is owned by another user): it logs `Error saving world!` and carries on in memory,
+so the only visible symptom is a stale world after the next restart. Odin logs that line
+at `ERROR` and sends a `Save Failed` notification on the first failure of a streak, then
+`Save Successful` once a save goes through again. Both use the `WEBHOOK_STATUS_FAILED` /
+`WEBHOOK_STATUS_SUCCESSFUL` switches. Odin also refuses to start the server at all when the
+save directory is not writable, since a server that cannot save is worse than one that
+does not start.
+
 ## Silencing Discord Notifications
 
 Player join/leave events can make a busy server noisy. Setting

--- a/src/odin/commands/logs.rs
+++ b/src/odin/commands/logs.rs
@@ -1,4 +1,4 @@
-use crate::log_filters::{handle_launch_probes, handle_player_events};
+use crate::log_filters::{handle_launch_probes, handle_player_events, handle_save_events};
 use crate::utils::common_paths::log_directory;
 use crate::utils::environment::is_env_var_truthy;
 use anyhow::{Context, Result};
@@ -72,6 +72,7 @@ fn handle_line_core(path: &PathBuf, line: &str) {
   }
 
   handle_player_events(line);
+  handle_save_events(line);
 
   let file_name = match path.file_name().and_then(|name| name.to_str()) {
     Some(name) => name,
@@ -98,7 +99,7 @@ fn handle_line_core(path: &PathBuf, line: &str) {
 
   let level = if line.contains("WARNING") {
     Level::Warn
-  } else if line.contains("ERROR") {
+  } else if line.contains("ERROR") || line.contains("Error saving world!") {
     Level::Error
   } else if line.contains("Fallback handler could not load library") {
     Level::Debug

--- a/src/odin/commands/start.rs
+++ b/src/odin/commands/start.rs
@@ -17,6 +17,18 @@ pub fn invoke(dry_run: bool) {
   debug!(target: "commands_start", "Dry run condition: {dry_run}");
   info!(target: "commands_start", "Looking for burial mounds...");
   if !dry_run {
+    if let Err(e) = server::save_directory_write_checks() {
+      error!(target: "commands_start", "Save directory is not writable: {e}");
+      error!(
+        target: "commands_start",
+        "The server would start, but every world save would fail and progress would be lost on restart."
+      );
+      error!(
+        target: "commands_start",
+        "Make the mounted save volume writable by the container's uid:gid (for example `chown -R` it on the host)."
+      );
+      exit(1);
+    }
     match server::start_daemonized(config) {
       Ok(_) => info!(target: "commands_start", "Success, daemonized"),
       Err(e) => {

--- a/src/odin/log_filters/mod.rs
+++ b/src/odin/log_filters/mod.rs
@@ -1,5 +1,7 @@
 mod player;
 mod probes;
+mod save;
 
 pub use player::{handle_player_events, OnlinePlayer, PlayerList};
 pub use probes::handle_launch_probes;
+pub use save::handle_save_events;

--- a/src/odin/log_filters/save.rs
+++ b/src/odin/log_filters/save.rs
@@ -1,0 +1,68 @@
+use crate::notifications::enums::{
+  event_status::EventStatus, notification_event::NotificationEvent,
+};
+use log::{error, info};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+const SAVE_FAILED: &str = "Error saving world!";
+const SAVE_DONE: &str = "World save (";
+
+/// Whether the last world save failed. Only the first failure of a streak sends a webhook,
+/// since the game retries on every save interval.
+static SAVE_FAILING: AtomicBool = AtomicBool::new(false);
+
+/// Surfaces failed world saves. Valheim logs `Error saving world! <reason>` and keeps
+/// running, so without this the only sign is a stale world after the next restart.
+pub fn handle_save_events(line: &str) {
+  if let Some(pos) = line.find(SAVE_FAILED) {
+    let reason = line[pos + SAVE_FAILED.len()..]
+      .split("StackTrace:")
+      .next()
+      .unwrap_or("")
+      .trim();
+    error!("World save failed! The server keeps running but progress is not being written to disk: {reason}");
+    if !SAVE_FAILING.swap(true, Ordering::SeqCst) {
+      NotificationEvent::Save(EventStatus::Failed)
+        .send_notification(Some(format!("World save failed: {reason}")));
+    }
+  } else if line.contains(SAVE_DONE)
+    && line.contains("done. Total time")
+    && SAVE_FAILING.swap(false, Ordering::SeqCst)
+  {
+    info!("World save succeeded again.");
+    NotificationEvent::Save(EventStatus::Successful)
+      .send_notification(Some("World save succeeded again".to_string()));
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use serial_test::serial;
+
+  const FAILED_LINE: &str = "09/11/2026 19:26:13: Error saving world! Access to the path \"/home/steam/.config/unity3d/IronGate/Valheim/worlds_local/Dedicated/00_00__0_3.chunk\" is denied.  StackTrace:   at System.IO.FileStream..ctor (System.String path) [0x0019e] in <297b518d2c9f4ee5bb6b049e9ead4f70>:0 ";
+  const DONE_LINE: &str = "09/11/2026 19:21:39: World save (5/5) done. Total time [13ms]";
+
+  #[test]
+  #[serial]
+  fn failure_sets_the_flag_and_success_clears_it() {
+    std::env::remove_var("WEBHOOK_URL");
+    SAVE_FAILING.store(false, Ordering::SeqCst);
+    handle_save_events(FAILED_LINE);
+    assert!(SAVE_FAILING.load(Ordering::SeqCst));
+    handle_save_events(FAILED_LINE);
+    assert!(SAVE_FAILING.load(Ordering::SeqCst));
+    handle_save_events(DONE_LINE);
+    assert!(!SAVE_FAILING.load(Ordering::SeqCst));
+  }
+
+  #[test]
+  #[serial]
+  fn unrelated_lines_are_ignored() {
+    std::env::remove_var("WEBHOOK_URL");
+    SAVE_FAILING.store(false, Ordering::SeqCst);
+    handle_save_events("09/11/2026 19:21:39: World save (2/5) Chunks writing done [2ms]");
+    handle_save_events("09/11/2026 19:19:46: Game server connected");
+    assert!(!SAVE_FAILING.load(Ordering::SeqCst));
+  }
+}

--- a/src/odin/notifications/enums/notification_event.rs
+++ b/src/odin/notifications/enums/notification_event.rs
@@ -20,6 +20,7 @@ pub enum NotificationEvent {
   Update(EventStatus),
   Start(EventStatus),
   Stop(EventStatus),
+  Save(EventStatus),
   Player(PlayerStatus),
 }
 
@@ -179,7 +180,7 @@ impl fmt::Display for NotificationEvent {
 impl std::str::FromStr for NotificationEvent {
   type Err = VariantNotFound;
   fn from_str(s: &str) -> Result<NotificationEvent, Self::Err> {
-    use NotificationEvent::{Broadcast, Player, Start, Stop, Update};
+    use NotificationEvent::{Broadcast, Player, Save, Start, Stop, Update};
     let parts: Vec<&str> = s.split(' ').collect();
     let event = parts[0];
     if event.eq(Broadcast.to_string().as_str()) {
@@ -194,6 +195,7 @@ impl std::str::FromStr for NotificationEvent {
         "Update" => Ok(Update(event_status)),
         "Start" => Ok(Start(event_status)),
         "Stop" => Ok(Stop(event_status)),
+        "Save" => Ok(Save(event_status)),
         _ => Err(VariantNotFound {
           v: String::from("Failed to find Notification Event"),
         }),

--- a/src/odin/server/install.rs
+++ b/src/odin/server/install.rs
@@ -793,10 +793,6 @@ pub(crate) fn reset_download_state(install_dir: &Path, app_id: i64) -> Result<Ve
 }
 
 fn preflight_write_checks(staged_install: bool) -> Result<(), String> {
-  use std::fs::{remove_file, OpenOptions};
-  use std::io::Write;
-  use std::time::{SystemTime, UNIX_EPOCH};
-
   let workdir = get_working_dir();
   let paths = vec![
     "/home/steam/Steam".to_string(),
@@ -816,6 +812,30 @@ fn preflight_write_checks(staged_install: bool) -> Result<(), String> {
     paths.push("/home/steam/.staging".to_string());
   }
 
+  write_checks(&paths)?;
+  save_directory_write_checks()
+}
+
+/// The directories the game writes its world into. Valheim keeps running when a save fails
+/// (it logs `Error saving world!` and carries on in memory), so an unwritable save directory
+/// means every autosave silently fails and a restart loads a stale world.
+pub fn save_directory_write_checks() -> Result<(), String> {
+  let saves = common_paths::saves_directory();
+  let worlds = format!("{saves}/worlds_local");
+  let mut paths = vec![saves, worlds.clone()];
+  let world = environment::fetch_var("WORLD", "");
+  if !world.is_empty() {
+    paths.push(format!("{worlds}/{world}"));
+  }
+  write_checks(&paths)
+}
+
+/// Probe each existing directory with a temporary file; missing paths are skipped.
+fn write_checks(paths: &[String]) -> Result<(), String> {
+  use std::fs::{remove_file, OpenOptions};
+  use std::io::Write;
+  use std::time::{SystemTime, UNIX_EPOCH};
+
   let now_ns = SystemTime::now()
     .duration_since(UNIX_EPOCH)
     .map_err(|e| e.to_string())?
@@ -823,7 +843,7 @@ fn preflight_write_checks(staged_install: bool) -> Result<(), String> {
 
   for p in paths {
     debug!("Testing write access: {}", p);
-    let dir = Path::new(&p);
+    let dir = Path::new(p);
     if !dir.exists() {
       debug!("Skipping write check (missing): {}", p);
       continue;
@@ -980,6 +1000,33 @@ mod tests {
   use std::fs;
   use tempfile::tempdir;
   use test_case::test_case;
+
+  #[test]
+  #[serial_test::serial]
+  fn save_directory_write_checks_probe_the_world_directory() {
+    use std::os::unix::fs::PermissionsExt;
+    let saves = tempdir().unwrap();
+    let world = saves.path().join("worlds_local").join("Dedicated");
+    fs::create_dir_all(&world).unwrap();
+    env::set_var("SAVE_LOCATION", saves.path());
+    env::set_var("WORLD", "Dedicated");
+
+    assert!(save_directory_write_checks().is_ok());
+
+    // Root ignores directory modes, so the negative case only holds for other users.
+    fs::set_permissions(&world, fs::Permissions::from_mode(0o555)).unwrap();
+    let probe = world.join("probe");
+    let unprivileged = fs::File::create(&probe).is_err();
+    if unprivileged {
+      let err = save_directory_write_checks().unwrap_err();
+      assert!(err.contains("worlds_local/Dedicated"), "{err}");
+    }
+    fs::set_permissions(&world, fs::Permissions::from_mode(0o755)).unwrap();
+    let _ = fs::remove_file(probe);
+
+    env::remove_var("SAVE_LOCATION");
+    env::remove_var("WORLD");
+  }
 
   #[test_case(
     false,


### PR DESCRIPTION
# Description

Takes in [#1518](https://github.com/mbround18/valheim-docker/pull/1518) from @ksc98 — their commit is merged here unchanged, so please **merge, don't squash**, to keep their authorship — and adds a container-level regression test for it.

Fixes #1515.

## Their fix

When the mounted save volume is not writable by the container's uid, the Valheim server **keeps running**: it loads the world, reports healthy, players join, and every save interval it logs `Error saving world! Access to the path ... is denied.` and carries on in memory. The world on disk and every backup Odin takes from it stay at the state they had at load. The first visible symptom is the next restart loading a stale world, by which point the progress is gone.

Two changes:

1. `odin start` and the install preflight probe `SAVE_LOCATION`, `worlds_local` and `worlds_local/<WORLD>`, and refuse to launch when one is unwritable — a server that cannot save is worse than one that does not start.
2. A log filter raises `Error saving world!` to `ERROR` and sends a `Save Failed` webhook on the first failure of a streak, then `Save Successful` when saves recover, gated by the existing `WEBHOOK_STATUS_FAILED` / `WEBHOOK_STATUS_SUCCESSFUL` switches.

## Review notes

- The probe loop is the existing `preflight_write_checks` body lifted into `write_checks` verbatim, so the install preflight behaves as before plus the save paths.
- Missing directories are skipped, so a first run with no `worlds_local` yet is not blocked.
- The success match requires both `World save (` and `done. Total time`, so the intermediate `Chunks writing done` line does not clear the failure flag. Their test pins that.
- The new `Save` variant inherits `Display` and gets its `FromStr` arm; no existing event changes shape.
- **Security review: clean.** The one path worth tracing is the untrusted game log line reaching a webhook. `event_message` is serde-serialized for plain webhooks, and for Discord it enters the handlebars template only as a value escaped through `serde_json::to_string`. Nothing derives a shell command, path or URL from the line, and it never reaches huginn's HTTP surface.

## What I added

`.github/scripts/save-dir-preflight-test.sh`, in the same style as `check-image-permissions.sh`, run from the image job on every PR. It runs the built image as uid 1000 against a save volume whose `worlds_local/Dedicated` it cannot write, and requires `odin start` to:

- refuse to start, with an error naming the directory at fault;
- still start when the volume is writable;
- leave no `.write_test_*` probe files behind in the save volume.

It never installs the game, so it is cheap enough to run outside the `e2e` label.

## Testing

- `cargo test --workspace` — 566 tests pass, including their three new ones; `cargo clippy --workspace --all-targets -D warnings` and `cargo fmt --check` clean.
- The new script against **this branch**: all three checks pass, with `Save directory is not writable: WRITE FAIL /saves/worlds_local/Dedicated: Permission denied (os error 13)`.
- The same script against an image built from **main**: `odin start` logs `Everything looks good! Running normally!` with an unwritable save directory — the bug — and the script fails. So it is a real regression test, not a passing decoration.

## Checklist

- [x] I added one or multiple labels which best describes this PR.
- [x] I have tested the changes locally.
- [ ] This PR has a reviewer on it.
- [x] I have validated my changes in a docker container and on Ubuntu. (Only needed for Odin or Docker Changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
